### PR TITLE
edits for v0.6 draft...see notes

### DIFF
--- a/OpenCDC-Specification-MD.md
+++ b/OpenCDC-Specification-MD.md
@@ -1,0 +1,2144 @@
+OpenCDC Specification -- Draft v0.6
+
+# OpenCDC
+
+# Open Change Data Capture Specification
+
+Draft v0.6 -- June 2026
+
+Status: Draft for Discussion
+
+OpenCDC Working Group
+
+**Abstract**
+This document specifies OpenCDC, a vendor-neutral JSON format for change data capture event streams. OpenCDC uses CloudEvents v1.1 as its envelope layer, combined with a schema-first payload design that provides full type fidelity across heterogeneous database engines. The standard mandates self-describing, schema-inline streams that are independently consumable without external infrastructure dependencies. It defines canonical representations for DML operations, DDL events, transaction identity, schema evolution, and stream lifecycle events. Type system semantics are defined in the companion OpenCDC Type System Proposal (v0.2), which is a normative reference to this specification. This document is written for implementers -- engineers at CDC tool vendors, database vendors, and pipeline platform teams who will produce or consume conformant OpenCDC streams. All behavioral requirements use RFC 2119 terminology (MUST, MUST NOT, SHOULD, SHOULD NOT, MAY).
+
+# Change Log
+
+- **v0.6**
+  - Date: June 2026
+  - Summary of Changes: Editorial and structural refactor toward a producer-focused normative core; no change to producer wire contract, field semantics, ordering guarantees, or type rules. (1) Design-decision narrative extracted to the new companion OpenCDC Architecture Decision Record (ADR) v0.1: former Section 2.9 (architecture evaluation), Section 18 (Design Decision Record), and Appendix A (Design Rationale) removed from this document; competitive/comparative asides in Sections 9 and 10.2 trimmed to neutral technical rationale. (2) Superficial vendor-tool mentions and specific User Story citations removed; vendor references retained only where a source-engine type or behavior is needed to define a concept. (3) Consumer behavior reframed as non-normative for this specification: former Section 7 (Consumer Contract), Section 11.3 (consumer idempotency obligations), and Section 16 (Implementation Safety Notes) relocated to the new Appendix A (Consumer Conformance, Obligations & Service-Level Guidance). Consumer mentions remaining in the body are illustrative only. Document Authority and Scope updated to state the producer-focused scope. Pre-existing broken cross-references corrected (Section 7 -> Section 8 for replay; Section 15 -> Section 17 for the Normative Summary).
+
+- **v0.5**
+  - Date: May 2026
+  - Summary of Changes: Section 10.2 TRUNCATE fully reworked: classification rationale added; transactional vs. non-transactional engine behavior defined; multi-table TRUNCATE addressed. New optional truncate_details object with three flags (cascade, sequence_reset, multi_table) using four-value semantics (true | false | "not_applicable" | "unknown"). propagated_tables explicitly deferred. New producer rule P-ORD-7 (multi-table TRUNCATE ordering). New consumer Section 7.6 (C-TRUNC-1 through C-TRUNC-4). Section 8.3 extended with non-transactional TRUNCATE / synthetic cdcxid rules. Section 2.8 TRUNCATE conformance refinement note. New normative rules P-TRUNC-1 through P-TRUNC-4 and C-TRUNC-1 through C-TRUNC-3 in Section 17. New TRUNCATE design decision in Section 18. New compliance matrix rows and conformance test scenarios T-11 through T-14 in Section 19. New Appendix A.11, A.12, A.13 design rationale.
+
+- **v0.4**
+  - Date: May 2026
+  - Summary of Changes: Section 4 restructured: four named schema delivery modes (Schema on Change, Schema on Reconnect, Schema on Each Event, Schema by Reference) with Reconnect Coverage constraint. New Section 4.5 Expected Producer Behaviors. Schema on Batch Envelope removed. STREAM_METADATA gains schema_delivery and sequence_continuity. Sequencing: renamed pos.sequence to pos.lsn_offset. CloudEvents sequence defined as producer-synthetic, uint64-range decimal string, session-scoped, gaps permitted. New Section 8.4 Sequence Discontinuity with five canonical scenarios. HEARTBEAT gains lsn_reset and sequence_reset. New P-SCHEMA and P-SEQ/C-SEQ normative rules in Section 17. Appendix A: Design Rationale added.
+
+- **v0.1**
+  - Date: Mar 2026
+  - Summary of Changes: Initial draft. CloudEvents envelope, new payload structure proposed, per-row typed column descriptors, schema delivery options, lifecycle events.
+
+- **v0.2**
+  - Date: May 2026 (patch v0.3)
+  - Summary of Changes: Renamed CDC-OIS -> OpenCDC throughout. Adopted schema-before-first-use as sole mandatory baseline. Aligned column typing with Type System Proposal v0.2: type metadata moves to OBJECT_METADATA; DML payloads carry values only. Added: Producer Contract, Consumer Contract, Idempotency & Deduplication, Loop Prevention, Replay Semantics, Partial UPDATE support (changed_columns), Observability fields, Security section, Quick Start. Hardened MUST/SHOULD/MAY language. Added normative reference to Type System Proposal and User Stories.
+
+# Normative References
+
+The following documents are normative references to this specification. Conformance with this specification requires conformance with the applicable sections of each normative reference.
+
+- **OpenCDC Type System Proposal v0.2 (May 2026)**
+  - Role: Normative. Defines the two-layer type system (source_type + logical_type), the canonical type vocabulary of ~60 named types, wire encoding rules for all types, and six type-system normative rules. The OBJECT_METADATA column descriptor structure defined in Section 4.4 of the Type System Proposal is normative for this specification.
+
+- **CloudEvents Specification v1.1 cloudevents.io**
+  - Role: Normative. Defines the envelope layer. All OpenCDC events MUST be valid CloudEvents v1.1 documents. Extension attribute naming conventions and structured/binary content mode definitions apply.
+
+- **RFC 2119 -- Key Words for Use in RFCs tools.ietf.org/html/rfc2119**
+  - Role: Normative. MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL carry the meanings defined therein.
+
+- **ISO 8601:2019 -- Date and Time**
+  - Role: Normative. All timestamp and duration values in OpenCDC payloads MUST use ISO 8601 / RFC 3339 string encoding.
+
+- **JSON Schema 2020-12 json-schema.org**
+  - Role: Normative. OBJECT_METADATA events MUST include a conformant json_schema block. Closed-world enforcement (additionalProperties: false) is mandatory on all schema definitions.
+
+The following documents are informative references:
+
+- **OpenCDC Architecture Decision Record (ADR) v0.1 (June 2026)**
+  - Role: Informative. Records the design decisions behind this specification -- the alternatives considered, the option adopted, and the consequences -- in numbered ADR entries. Provides the "why" behind constraints stated normatively here. Nothing in the ADR overrides normative text in this specification.
+
+- **OpenCDC User Stories & Use Cases v4 (May 2026)**
+  - Role: Informative. Defines six use cases (Stories 1-6) that motivate the specification's interoperability, type fidelity, idempotency, loop prevention, and transport-agnostic requirements. Acceptance criteria in the user stories serve as validation benchmarks for conformance testing.
+
+# Document Authority and Scope
+
+OpenCDC is defined across three documents with distinct roles. Understanding which document governs which decisions is essential for preventing divergent vendor implementations.
+
+- **OpenCDC Specification (this document)**
+  - Is Authoritative For: Event structure, field names, ordering guarantees, producer/consumer contracts, lifecycle events, idempotency, replay semantics, loop prevention, security, operational modes
+  - Role: Normative
+
+- **OpenCDC Type System Proposal v0.2**
+  - Is Authoritative For: All logical_type definitions, source_type-to-logical_type mapping rules, wire encoding rules per type, type-specific parameters, special value handling (NaN, Infinity, DECFLOAT, LOB overflow encoding)
+  - Role: Normative
+
+- **OpenCDC User Stories v4**
+  - Is Authoritative For: Validation scenarios and acceptance criteria for conformance testing. Motivation for specification decisions.
+  - Role: Informative
+
+**Producer-Focused Scope**
+This specification defines the mandatory and optional behaviors of OpenCDC *producers* -- the structure, semantics, ordering, type fidelity, and lifecycle of the events a producer emits. Its purpose is to guarantee that a consumer can read and interpret a producer's stream with full fidelity. It does not mandate how a consumer processes those events: different consumers legitimately require different service levels (for example, a financial replication target needs strict transactionality and exact type fidelity, while a reporting tool computing coarse rolling averages may not). Consumer behavior described in the body of this specification is therefore illustrative -- it shows how an object or guarantee is intended to be used and is not a conformance mandate. The behaviors a consumer should adopt to achieve a given service level against a conformant producer are collected, as non-normative guidance, in Appendix A (Consumer Conformance, Obligations & Service-Level Guidance).
+
+**When Documents Appear to Conflict**
+If this Specification and the Type System Proposal appear to conflict on a type-related question, the Type System Proposal is authoritative. If they conflict on event structure or ordering, this Specification is authoritative. Any duplication of type rules in this Specification is non-normative. Implementers MUST treat the Type System Proposal as the definitive source for logical_type definitions, wire encoding rules, and type semantics.
+
+# 1. Quick Start -- Minimal Conformant Stream
+
+This section shows the minimum viable OpenCDC stream for a single-table producer. A minimal conformant session opens with three event types in order: a STREAM_METADATA event at session start, an OBJECT_METADATA event establishing the table schema before any row events, then DML events that reference that schema by id. No external tooling, registry, or broker is required to parse this stream.
+
+```
+// -- Step 1: Session open (emitted at the start of every consumer session) --
+{
+  "specversion":    "1.1",
+  "id":             "stream-meta-001",
+  "source":         "//db-prod.acme.com/sales",
+  "type":           "com.acme.cdc.meta.STREAM_METADATA",
+  "time":           "2026-05-03T10:00:00.000Z",
+  "datacontenttype":"application/json",
+  "cdcspecversion": "0.2",
+  "data": {
+    "producer":        "Acme CDC Tool 1.0",
+    "opencdc_version": "0.2",
+    "source_db":       "PostgreSQL 17",
+    "tables":          ["sales.ORDERS"],
+    "heartbeat_interval_seconds": 30
+  }
+}
+// -- Step 2: Schema event (emitted once before first DML for this table) --
+{
+  "specversion":    "1.1",
+  "id":             "schema-ORDERS-v1",
+  "source":         "//db-prod.acme.com/sales",
+  "subject":        "sales.ORDERS",
+  "type":           "com.acme.cdc.meta.OBJECT_METADATA",
+  "time":           "2026-05-03T10:00:00.000Z",
+  "datacontenttype":"application/json",
+  "cdcspecversion": "0.2",
+  "data": {
+    "table": { "schema": "sales", "name": "ORDERS" },
+    "schema_version": 1,
+    "primary_key": ["ORDER_ID"],
+    "columns": [
+      { "name":"ORDER_ID", "ordinal":1, "source_type":"INTEGER",
+        "logical_type":"INT32",   "parameters":{}, "nullable":false, "pk":true  },
+      { "name":"STATUS",   "ordinal":2, "source_type":"VARCHAR(20)",
+        "logical_type":"STRING",  "parameters":{"max_length":20,"length_semantics":"CHAR"}, "nullable":false, "pk":false },
+      { "name":"AMOUNT",   "ordinal":3, "source_type":"DECIMAL(10,2)",
+        "logical_type":"DECIMAL", "parameters":{"precision":10,"scale":2}, "nullable":false, "pk":false }
+    ],
+    "json_schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:opencdc:schema:sales.ORDERS:v1",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ORDER_ID": { "oneOf": [{"type":"integer"},{"type":"null"}] },
+        "STATUS":   { "oneOf": [{"type":"string"}, {"type":"null"}] },
+        "AMOUNT":   { "oneOf": [{"type":"string"}, {"type":"null"}] }
+      }
+    }
+  }
+}
+// -- Step 3: DML event (values only -- no type metadata repeated) --
+{
+  "specversion":    "1.1",
+  "id":             "7f3a2b10-e14c-4d8a-9f62-3c1d8e4b5a09",
+  "source":         "//db-prod.acme.com/sales",
+  "subject":        "sales.ORDERS",
+  "type":           "com.acme.cdc.dml.INSERT",
+  "time":           "2026-05-03T10:01:00.000Z",
+  "datacontenttype":"application/json",
+  "dataschema":     "schema-ORDERS-v1",
+  "cdcspecversion": "0.2",
+  "cdcxid":         "txn-00000001",
+  "cdctxorder":     0,
+  "cdcpos":         "0000000100000001:0",
+  "partitionkey":   "42",
+  "data": {
+    "table":       { "schema": "sales", "name": "ORDERS" },
+    "primary_key": ["ORDER_ID"],
+    "before":      null,
+    "after": {
+      "ORDER_ID": 42,
+      "STATUS":   "PENDING",
+      "AMOUNT":   "199.99"
+    },
+    "_null_columns":  [],
+    "_lob_overflow":  [],
+    "pos": {
+      "lsn":             "0000000100000001",
+      "source_timestamp":"2026-05-03T10:00:59.100Z",
+      "lsn_offset":      0,
+      "native_position": "<source-specific-opaque-value>"
+    }
+  }
+}
+```
+
+**What a Conformant Consumer Does With This**
+
+1. Receive STREAM_METADATA. Cache producer identity, table list, and heartbeat interval.
+2. Receive OBJECT_METADATA "schema-ORDERS-v1". Cache columns[] keyed by name. Note schema_version=1.
+3. Receive INSERT event. Verify dataschema="schema-ORDERS-v1" is cached. Resolve logical_type for each column from cache: ORDER_ID=INT32 (JSON integer), STATUS=STRING (UTF-8), AMOUNT=DECIMAL (exact decimal string).
+4. Apply INSERT. Acknowledge pos.lsn + pos.lsn_offset as the structured resume position. Save cdcpos as the primary resume handle.
+5. On reconnect: producer re-emits STREAM_METADATA and current OBJECT_METADATA before resuming data delivery (see Section 6).
+
+# 2. Design Principles
+
+These principles are the foundation for every normative decision in this specification. When requirements conflict, higher-numbered principles yield to lower-numbered ones.
+
+## 2.1 Infrastructure Independence
+
+A conformant OpenCDC stream MUST be fully consumable with only a JSON parser and this specification document. No message broker, schema registry, SDK, or vendor-specific tooling is required to parse, validate, or apply a conformant stream. External infrastructure (Kafka, registries, etc.) is permitted as an optimization but MUST NOT be required for conformance.
+
+## 2.2 Self-Describing Streams
+
+Schema documents are first-class events in the stream. A consumer MUST be able to determine the complete type structure of any data event by reading only the events that precede it in the stream. Schema and data MUST be co-located and ordered. No out-of-band schema distribution is required.
+
+## 2.3 No-Transformation Interoperability
+
+A producer that emits conformant OpenCDC events MUST produce events that a conformant consumer can apply without source-specific transformation logic. This is a central interoperability requirement (see the OpenCDC User Stories document for the motivating use cases): independently built producers and consumers running on different database engines and CDC tools must be able to exchange events directly. Any event that requires consumer-side knowledge of the originating vendor to decode is non-conformant.
+
+## 2.4 Closed-World Schemas
+
+Every OBJECT_METADATA event MUST include a json_schema block with additionalProperties: false. Unrecognized fields in a DML payload are a validation failure, not a warning. This gives consumers a precise contract: if a field appears in a DML payload, it was declared in the schema. If it was not declared, the producer is non-conformant.
+
+## 2.5 DDL as a First-Class Citizen
+
+Schema changes MUST be emitted as DDL events in the same ordered stream as data events. A consumer MUST be able to detect and handle schema evolution by reading only the stream -- no out-of-band notification, polling, or database introspection is required.
+
+## 2.6 Source Agnosticism
+
+The OpenCDC core standard contains no Oracle-specific, MySQL-specific, or PostgreSQL-specific constructs. Source-native type information is isolated in the source_type field of the OBJECT_METADATA column descriptor, where it is available for passthrough but does not affect canonical interpretation. Canonical interpretation is always driven by logical_type.
+
+## 2.7 Payload Encoding Agnosticism
+
+JSON is used as the normative example format throughout this specification. It is NOT the mandatory wire encoding. Conformant implementations MAY use any serialization format -- Avro, Protocol Buffers, Parquet, Arrow IPC, or others -- provided the logical structure, field semantics, and type encoding rules defined in this specification and the OpenCDC Type System Proposal are preserved.
+
+The following rules apply to all encoding formats:
+
+- The logical field names and structure (specversion, id, source, type, data, columns[], before, after, _null_columns, _lob_overflow, etc.) MUST be preserved in any encoding. An Avro schema representing an OpenCDC event MUST contain fields that map 1:1 to the JSON field names defined here.
+
+- Wire encoding rules for each logical_type (defined in the Type System Proposal v0.2) apply regardless of the outer serialization format. An ORACLE_DATE column MUST carry a datetime value whether the payload is JSON, Avro, or Protobuf.
+
+- Closed-world enforcement (additionalProperties: false) MUST be applied in the encoding's schema language equivalent. For Avro, this means no fields outside the declared schema. For Protobuf, unknown fields MUST be rejected by conformant consumers.
+
+- JSON examples in this specification are normative for field names and structure. They are informative for encoding format. A producer that emits the same logical content in Avro is conformant; a producer that omits fields or changes their semantics is non-conformant regardless of encoding.
+
+**Why JSON as the Normative Example?**
+JSON is the lowest-common-denominator format: every platform, language, and tool can parse it without dependencies. Using JSON as the normative example ensures the specification is verifiable without vendor tooling -- any implementer can validate a conformant stream with a text editor and a JSON Schema validator. High-throughput deployments (for example, lakehouse ingestion or Arrow Flight transports) may use binary formats for wire efficiency. These are valid conformant implementations provided the field structure and type semantics are preserved.
+
+**JSON Schema Is the Canonical Schema Representation**
+The json_schema block in every OBJECT_METADATA event MUST be a valid JSON Schema 2020-12 document. This is non-negotiable regardless of the payload encoding format chosen. Implementations using alternative wire encodings (Avro, Protobuf, Arrow IPC) MUST enforce equivalent constraints in their own schema system: (1) all fields declared in the JSON Schema MUST have equivalents in the alternative schema; (2) closed-world enforcement (no additional fields beyond those declared) MUST be preserved -- for Avro this means no fields outside the declared schema, for Protobuf this means unknown fields MUST be rejected; (3) the JSON Schema MUST still be included in the OBJECT_METADATA event regardless of the wire encoding, so that any conformant validator can inspect it without vendor tooling.
+
+## 2.8 Interoperability Profile -- Minimum Viable Standard
+
+To ensure that partial implementations can interoperate, OpenCDC defines a Minimum Viable Interoperability Profile. An implementation that claims OpenCDC conformance MUST support all features in this profile. Features beyond this profile are OPTIONAL unless specifically marked MUST elsewhere in the specification.
+
+- **DML Operations**
+  - Producer MUST: Emit INSERT, UPDATE, DELETE with correct before/after semantics
+  - Consumer MUST: Accept and apply INSERT, UPDATE, DELETE using before/after state
+
+- **Schema Delivery**
+  - Producer MUST: Emit OBJECT_METADATA before first DML for each table and after DDL (Schema on Change, mandatory). Implement at least one of: Schema on Reconnect or Schema on Each Event. Declare active modes in STREAM_METADATA schema_delivery object.
+  - Consumer MUST: Cache OBJECT_METADATA; reject DML whose dataschema is not cached
+
+- **Canonical Type System**
+  - Producer MUST: Populate source_type (verbatim DDL) and logical_type (OpenCDC vocabulary) in every column descriptor
+  - Consumer MUST: Resolve column types from logical_type in OBJECT_METADATA; decode values per wire encoding rules
+
+- **LOB State Signaling**
+  - Producer MUST: Populate _null_columns and _lob_overflow in every DML event
+  - Consumer MUST: Distinguish genuinely null LOB from uncaptured LOB via _null_columns / _lob_overflow
+
+- **Idempotency**
+  - Producer MUST: Assign stable UUID id; preserve id during replay
+  - Consumer MUST: Deduplicate on (source, id); silently discard duplicates
+
+- **Transaction Ordering**
+  - Producer MUST: Emit all events of a transaction before any event of the next transaction; assign monotonic cdctxorder
+  - Consumer MUST: Apply events in cdctxorder sequence within each cdcxid group
+
+- **Stream Liveness**
+  - Producer MUST: Emit HEARTBEAT during idle periods
+  - Consumer MUST: Monitor HEARTBEAT to distinguish idle from broken stream
+
+Stretch features (UPSERT, TRUNCATE, SNAPSHOT, bidirectional sync loop prevention, partial UPDATE images, Observability fields) are RECOMMENDED but not required for minimum profile conformance.
+
+TRUNCATE conformance refinement: A producer that emits TRUNCATE events and whose source engine exposes truncate execution options (such as cascade behavior or identity-sequence reset behavior) SHOULD populate the truncate_details object defined in Section 10.2. A producer that emits TRUNCATE events for an engine that does not expose such options (or cannot observe them from the capture layer) MAY omit truncate_details entirely. A producer that omits truncate_details is conformant; a producer that populates truncate_details with incorrect or fabricated values is non-conformant. See Section 10.2 for the full truncate_details specification and per-engine guidance.
+
+# 3. CloudEvents Envelope
+
+OpenCDC adopts CloudEvents v1.1 as its mandatory envelope specification. Every OpenCDC event MUST be a valid CloudEvents v1.1 document. CloudEvents is implemented across AWS EventBridge, Azure Event Grid, GCP Eventarc, Knative, and hundreds of other systems -- using it as the envelope layer provides infrastructure-layer routing and filtering without CDC-specific tooling.
+
+## 3.1 Mandatory CloudEvents Fields
+
+- **specversion**
+  - Required: MUST
+  - Value / Constraint: Always "1.1"
+
+- **id**
+  - Required: MUST
+  - Value / Constraint: UUID v4. Globally unique per event. Used as the idempotency key: (source, id) is the deduplication key for consumers.
+
+- **source**
+  - Required: MUST
+  - Value / Constraint: URI identifying the origin system and database. Format: //{host}/{instance}/{schema}. Example: //oracle-prod.acme.com/ORCL/FINANCE
+
+- **subject**
+  - Required: MUST
+  - Value / Constraint: Fully qualified table identifier. Format: {schema}.{table}. Example: FINANCE.ORDERS
+
+- **type**
+  - Required: MUST
+  - Value / Constraint: Reverse-DNS event type. See Section 3.2 for the full vocabulary.
+
+- **time**
+  - Required: MUST
+  - Value / Constraint: RFC 3339 timestamp of the source commit. MUST be the database commit time, not the capture or publish time.
+
+- **datacontenttype**
+  - Required: MUST
+  - Value / Constraint: Always "application/json"
+
+- **dataschema**
+  - Required: MUST (DML/DDL)
+  - Value / Constraint: CloudEvents id of the most recently emitted OBJECT_METADATA event for this table. Omitted for HEARTBEAT and STREAM_METADATA events.
+
+## 3.2 Operation Type Vocabulary
+
+The type field encodes the event category and operation. Infrastructure routers can filter on DDL vs. DML vs. lifecycle without deserializing the payload. Producers MUST use full English names from this vocabulary -- single-character codes are non-conformant.
+
+```
+# DML operations (data changes)
+com.{org}.cdc.dml.INSERT
+com.{org}.cdc.dml.UPDATE
+com.{org}.cdc.dml.DELETE
+com.{org}.cdc.dml.UPSERT      # explicit upsert -- not an INSERT+DELETE pair
+com.{org}.cdc.dml.TRUNCATE    # delete all rows; no before/after image; NOTE: transactional in PostgreSQL/SQL Server, DDL (implicit commit) in Oracle/MySQL -- see Section 10.2
+# DDL operations (schema changes)
+com.{org}.cdc.ddl.CREATE
+com.{org}.cdc.ddl.ALTER
+com.{org}.cdc.ddl.DROP
+# Lifecycle / metadata
+com.{org}.cdc.meta.STREAM_METADATA    # stream-level metadata at session start
+com.{org}.cdc.meta.OBJECT_METADATA    # table schema -- mandatory before first DML
+com.{org}.cdc.meta.HEARTBEAT          # liveness signal during idle periods
+# Snapshot (initial load)
+com.{org}.cdc.snapshot.READ           # full row at snapshot time; before=null
+```
+
+**Replace {org} with your organization's reverse-DNS domain**
+Example: com.oracle.cdc.dml.INSERT, com.ibm.cdc.dml.UPDATE. The {org} segment identifies the producer organization, not the source database vendor. A multi-vendor conformance validator checks the type suffix (.INSERT, .ALTER, etc.), not the org prefix.
+
+## 3.3 CloudEvents Extension Attributes for OpenCDC
+
+CDC-specific envelope fields that have no CloudEvents native equivalent are carried as extension attributes. All OpenCDC extension attributes MUST use the cdc prefix.
+
+- **cdcspecversion**
+  - Type: String
+  - Required: MUST
+  - Description: OpenCDC spec version. "0.2" for this revision. Distinct from CloudEvents specversion.
+
+- **cdcxid**
+  - Type: String
+  - Required: MUST (DML/DDL)
+  - Description: Transaction identifier, source-normalized to a human-readable string. All events in the same source transaction carry the same cdcxid value. Format is source-specific but MUST be stable and unique within the stream.
+
+- **cdctxorder**
+  - Type: Integer
+  - Required: MUST (DML/DDL)
+  - Description: 0-based ordinal position of this event within its transaction. (cdcxid, cdctxorder) pairs MUST be unique and monotonically increasing within a transaction.
+
+- **cdcpos**
+  - Type: String
+  - Required: MUST
+  - Description: Opaque, stable stream position for consumer resume/replay. Consumers MUST treat this as an opaque string -- do not parse. See Section 8 (Position and Replay Semantics).
+
+- **partitionkey**
+  - Type: String
+  - Required: SHOULD
+  - Description: Set to the primary key hash of the changed row. Ensures a partitioned transport keeps related rows on the same partition. This is the official CloudEvents partitioning extension. CRITICAL: All events belonging to the same transaction (same cdcxid) MUST be assigned the same partitionkey. A producer that emits events of a single transaction across multiple partitionkey values is non-conformant -- transaction integrity cannot be guaranteed across independent partitions.
+
+- **sequence**
+  - Type: String
+  - Required: SHOULD
+  - Description: Producer-assigned global stream counter. This is the official CloudEvents sequence extension attribute. Provides total ordering of all events emitted by this producer within a connected session, across all tables and partitions. Value MUST be a non-negative decimal integer encoded as a string, no leading zeros (e.g., "10042"). Monotonically increasing within a session; gaps are permitted and MUST NOT be interpreted as dropped events. Session-scoped -- not guaranteed to be continuous across reconnects. Distinct from pos.lsn_offset (per-LSN disambiguator) and cdctxorder (per-transaction ordinal). See Section 8.4 for discontinuity handling.
+
+## 3.4 Bidirectional Sync -- Loop Prevention Field
+
+Bidirectional database-to-database sync (see the OpenCDC User Stories document) requires bidirectional event flow. Without a loop prevention mechanism, a change originating in System A will be applied by System B and then re-emitted back to System A, creating an infinite loop. OpenCDC defines the following mechanism:
+
+- The source CloudEvents field identifies the originating system (e.g., //aurora-prod.acme.com/sales). This value MUST reflect the database instance where the change originally occurred -- not the CDC tool that captured it.
+
+- A producer operating in bidirectional sync mode MUST NOT emit an event for a change whose source field matches its own source identifier. This is the loop suppression filter.
+
+- Producers MAY include an optional cdcsourceid extension attribute carrying a stable, unique identifier for the originating system (e.g., a UUID assigned at deployment time) for use cases where URI-based source comparison is insufficient.
+
+**Loop Prevention Is a Producer Obligation -- Consumer Filtering Is Defensive Only**
+Loop suppression MUST be implemented by the producer, not the consumer. A consumer that receives an event MUST apply it -- it has no reliable way to determine whether the event originated locally. The producer, which has access to the source transaction log, is the only party that can determine whether a committed transaction was a local origination or an applied remote event. The mechanism: producers that apply incoming OpenCDC events MUST tag the resulting local transactions with the original cdcxid value. When the CDC capture layer reads those transactions from the log, it MUST recognize the cdcxid tag and suppress emission of those events. Consumers MAY implement defensive loop filtering (e.g., rejecting events whose source matches their own system identifier) as an additional safety layer. However, consumers MUST NOT rely on defensive filtering as the primary loop prevention mechanism. Correct producer behavior is the only conformant solution. A consumer that silently discards events based on source matching without a conformant producer-side implementation creates a system that appears to work but will corrupt data if producer-side filtering ever fails.
+
+## 3.5 Canonical Envelope Example
+
+```
+{
+  // -- CloudEvents mandatory fields --
+  "specversion":     "1.1",
+  "id":              "7f3a2b10-e14c-4d8a-9f62-3c1d8e4b5a09",  // idempotency key
+  "source":          "//oracle-prod.acme.com/ORCL/FINANCE",
+  "subject":         "FINANCE.ORDERS",
+  "type":            "com.acme.cdc.dml.UPDATE",
+  "time":            "2026-03-22T14:23:01.000Z",               // commit time
+  "datacontenttype": "application/json",
+  "dataschema":      "schema-ORDERS-v2",                       // OBJECT_METADATA id
+  // -- OpenCDC extension attributes --
+  "cdcspecversion":  "0.2",
+  "cdcxid":          "1510528009.5.13.7625",
+  "cdctxorder":      2,
+  "cdcpos":          "0000012C000004D2:14",
+  "partitionkey":    "1001",
+  "sequence":        "10042",
+  // -- OpenCDC payload --
+  "data": { ... }   // see Section 4
+}
+```
+
+# 4. Schema Delivery -- OBJECT_METADATA and Producer Schema Modes
+
+Schema delivery is the most consequential design decision in a CDC standard. OpenCDC adopts schema-before-first-use as the single mandatory baseline. This section defines the OBJECT_METADATA event, its mandatory stream ordering, and producer obligations for consumer reconnection.
+
+## 4.1 Mandatory Baseline: Schema-Before-First-Use
+
+The following are MUST requirements for all conforming producers:
+
+- An OBJECT_METADATA event for a table MUST be emitted in the stream before any DML event (INSERT, UPDATE, DELETE, UPSERT, TRUNCATE) or snapshot.READ event for that table.
+
+- An OBJECT_METADATA event MUST be re-emitted after any DDL event that changes a table's structure (ALTER, DROP+CREATE), and before the first DML event for that table under the new structure.
+
+- DML event before and after value objects MUST carry column data values only. source_type, logical_type, parameters, and nullability MUST NOT appear within before or after row value objects — they reside in the OBJECT_METADATA column descriptor. When Schema on Each Event is active (Section 4.5.3), an additional _schema key MAY appear at the top level of the DML data object; this is the sole permitted location for per-event schema restatement and does not affect the values-only constraint on before/after.
+
+- The dataschema field of every DML event MUST equal the CloudEvents id of the most recently emitted OBJECT_METADATA event for its table.
+
+```
+MANDATORY STREAM ORDERING -- PRODUCER MUST ENFORCE (per consumer session):
+  [1]  STREAM_METADATA  (session-scoped: first event to this consumer -- NOT part of durable stream ordering)
+  [2]  OBJECT_METADATA  id:"schema-ORDERS-v1"      <- MUST precede [3]
+  [3]  INSERT           dataschema:"schema-ORDERS-v1"
+  [4]  UPDATE           dataschema:"schema-ORDERS-v1"
+  [5]  DDL ALTER        (adds TRACKING_CODE column)
+  [6]  OBJECT_METADATA  id:"schema-ORDERS-v2"      <- MUST precede [7]; MUST follow [5]
+  [7]  INSERT           dataschema:"schema-ORDERS-v2"
+  [8]  HEARTBEAT        (no schema ref required)
+
+  VIOLATION: emitting [3] before [2] -> non-conformant producer
+  VIOLATION: emitting [7] before [6] -> non-conformant producer
+  VIOLATION: emitting [3] before [1] (STREAM_METADATA) -> non-conformant producer
+  VIOLATION: emitting [6] referencing the same id as [2] after a DDL change -> non-conformant producer
+
+The four named schema delivery modes and their conformance levels are defined in Section 4.4. The behavioral obligations for each mode are defined in Section 4.5. Section 4.1 governs the unconditional ordering constraint (Schema on Change) that applies regardless of which optional modes are active.
+
+  VIOLATION: [6] referencing the same id as [2] after a DDL change -> non-conformant producer
+```
+
+## 4.2 OBJECT_METADATA Event Structure
+
+The OBJECT_METADATA event carries the complete column descriptor block. Its structure is normatively defined in the OpenCDC Type System Proposal v0.2, Sections 4.4 and 5.1. The following fields are mandatory in the data object:
+
+- **table**
+  - Required: MUST
+  - Description: Structured table identity object. See Section 5.1.
+
+- **schema_version**
+  - Required: MUST
+  - Description: Integer. Starts at 1. MUST increment by 1 when a DDL change alters the table's column structure. MUST NOT increment when OBJECT_METADATA is re-emitted for reconnection (Approach 1) or replay (Approach 2) without a structural change. Re-emitting an identical schema retains the same schema_version. Consumers use schema_version to detect genuine schema drift -- a version change signals that the column descriptors have changed and the consumer's schema cache MUST be fully replaced.
+
+- **primary_key**
+  - Required: MUST
+  - Description: Array of column name strings that constitute the CDC identity key. MUST match the source table's primary key or the configured surrogate key.
+
+- **columns**
+  - Required: MUST
+  - Description: Array of column descriptor objects. See Section 4.3.
+
+- **json_schema**
+  - Required: MUST
+  - Description: JSON Schema 2020-12 document. MUST enforce additionalProperties: false on the properties of the value payload. Used for validation of DML events referencing this schema.
+
+```
+{
+  "specversion":    "1.1",
+  "id":             "schema-FIN-ORDERS-v2",         // DML dataschema references this id
+  "source":         "//oracle-prod.acme.com/ORCL/FINANCE",
+  "subject":        "FINANCE.ORDERS",
+  "type":           "com.acme.cdc.meta.OBJECT_METADATA",
+  "time":           "2026-03-22T14:00:00.000Z",
+  "datacontenttype":"application/json",
+  "cdcspecversion": "0.2",
+  "data": {
+    "table": { "catalog": "ORCL", "schema": "FINANCE", "name": "ORDERS" },
+    "schema_version": 2,
+    "primary_key": ["ORDER_ID"],
+    "columns": [
+      {
+        "name":         "ORDER_ID",
+        "ordinal":      1,                        // 1-based column position
+        "source_type":  "NUMBER(10,0)",            // verbatim DDL -- never normalized
+        "logical_type": "DECIMAL",                 // from OpenCDC Type System vocabulary
+        "parameters":   { "precision": 10, "scale": 0 },
+        "nullable":     false,
+        "pk":           true
+      },
+      {
+        "name":         "STATUS",
+        "ordinal":      2,
+        "source_type":  "VARCHAR2(20 BYTE)",
+        "logical_type": "STRING",
+        "parameters":   { "max_length": 20, "length_semantics": "BYTE" },
+        "nullable":     false,
+        "pk":           false
+      },
+      {
+        "name":         "AMOUNT",
+        "ordinal":      3,
+        "source_type":  "NUMBER(10,2)",
+        "logical_type": "DECIMAL",
+        "parameters":   { "precision": 10, "scale": 2 },
+        "nullable":     false,
+        "pk":           false
+      },
+      {
+        "name":         "NOTES",
+        "ordinal":      4,
+        "source_type":  "CLOB",
+        "logical_type": "STRING_LOB",
+        "parameters":   {},
+        "nullable":     true,
+        "pk":           false,
+        "lob":          true                      // LOB capture constraints apply
+      },
+      {
+        "name":         "TRACKING_CODE",          // added by DDL ALTER in schema v2
+        "ordinal":      5,
+        "source_type":  "VARCHAR2(50 BYTE)",
+        "logical_type": "STRING",
+        "parameters":   { "max_length": 50, "length_semantics": "BYTE" },
+        "nullable":     true,
+        "pk":           false
+      }
+    ],
+    "json_schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id":     "urn:opencdc:schema:FINANCE.ORDERS:v2",
+      "type":    "object",
+      "additionalProperties": false,
+      "properties": {
+        "ORDER_ID":      { "oneOf": [{"type":"integer"}, {"type":"null"}] },
+        "STATUS":        { "oneOf": [{"type":"string"},  {"type":"null"}] },
+        "AMOUNT":        { "oneOf": [{"type":"string"},  {"type":"null"}] },
+        "NOTES":         { "oneOf": [{"type":"string"},  {"type":"null"}] },
+        "TRACKING_CODE": { "oneOf": [{"type":"string"},  {"type":"null"}] }
+      }
+    }
+  }
+}
+```
+
+## 4.3 Column Descriptor Fields
+
+- **name**
+  - Required: MUST
+  - Description: Column name exactly as it appears in the source DDL. Case-sensitive. Used as the key in DML value payload objects.
+
+- **ordinal**
+  - Required: MUST
+  - Description: 1-based integer column position in the source table. Used to reconstruct column order when the DML payload is applied to a target.
+
+- **source_type**
+  - Required: MUST
+  - Description: Verbatim DDL type declaration from the source engine. MUST NOT be normalized. Example: "TIMESTAMP(9) WITH TIME ZONE", "BIGINT UNSIGNED", "NUMBER(20,-2)".
+
+- **logical_type**
+  - Required: MUST
+  - Description: Named type from the OpenCDC canonical vocabulary (Type System Proposal v0.2 Section 6). Determines wire encoding for DML value payloads.
+
+- **parameters**
+  - Required: MUST
+  - Description: JSON object. Type-specific parameters (precision, scale, max_length, length_semantics, etc.). May be empty {}. See Type System Proposal for parameter definitions per logical_type.
+
+- **nullable**
+  - Required: MUST
+  - Description: Boolean. Whether the source column accepts NULL values.
+
+- **pk**
+  - Required: MUST
+  - Description: Boolean. Whether this column is part of the primary_key array.
+
+- **lob**
+  - Required: SHOULD
+  - Description: Boolean. True if this column has LOB capture constraints (CLOB, BLOB, LONGTEXT, etc.). Signals to consumers that _lob_overflow may appear for this column in DML events.
+
+Schema Delivery Modes:
+
+- **Schema on Change**
+  - Flag (STREAM_METADATA): schema_on_change
+  - Conformance: MANDATORY
+  - Description: OBJECT_METADATA emitted before first DML for each table and after any DDL that alters table structure. Always active; schema_on_change MUST always be true.
+
+- **Schema on Reconnect**
+  - Flag (STREAM_METADATA): schema_on_reconnect
+  - Conformance: OPTIONAL (see 4.5.2)
+  - Description: Current OBJECT_METADATA for all active tables is re-emitted at the start of every new consumer session. Default ON.
+
+- **Schema on Each Event**
+  - Flag (STREAM_METADATA): schema_on_each_event
+  - Conformance: OPTIONAL (see 4.5.3)
+  - Description: Full OBJECT_METADATA payload embedded inline in every DML event under the _schema key. Enables stateless consumption and mid-stream joins. Default OFF.
+
+- **Schema by Reference**
+  - Flag (STREAM_METADATA): schema_by_reference
+  - Conformance: OPTIONAL
+  - Description: The dataschema CloudEvents field is a resolvable URL to an external schema registry. Does not replace stream-embedded OBJECT_METADATA. Primary use case: deployments backed by an external schema registry. Default OFF.
+
+Conformance Rule -- Baseline: Schema on Change is unconditionally mandatory. The flag schema_on_change MUST always be true in STREAM_METADATA. A producer that emits schema_on_change: false is non-conformant.
+
+Conformance Rule -- Reconnect Coverage (CRITICAL): A producer MUST implement at least one of Schema on Reconnect or Schema on Each Event, in addition to Schema on Change. Schema by Reference alone does NOT satisfy this constraint -- relying solely on an external registry creates an infrastructure dependency that violates Section 2.1 (Infrastructure Independence). If a producer disables Schema on Reconnect (schema_on_reconnect: false), Schema on Each Event MUST be active (schema_on_each_event: true), and vice versa. A producer with both set to false is non-conformant.
+
+Conformance Rule -- Declaration: A producer MUST declare its active schema delivery modes in the schema_delivery object of the STREAM_METADATA event (Section 10.4). Consumers MUST read schema_delivery at connection time and adapt their schema acquisition behavior accordingly.
+
+## 4.5 Expected Producer Behaviors -- Schema Delivery
+
+This subsection defines the precise behavioral obligations for each schema delivery mode. It is a normative companion to the conformance rules in Section 4.4 and the full Producer Contract in Section 6.
+
+### 4.5.1 Schema on Change (MANDATORY)
+
+The producer MUST emit an OBJECT_METADATA event for a table before any DML event or snapshot.READ event for that table within a consumer session.
+
+The producer MUST emit a new OBJECT_METADATA event after any DDL event that alters a table's column structure (ALTER, DROP+CREATE), and before the first subsequent DML event for that table.
+
+The schema_version integer MUST increment by exactly 1 on each structural DDL change. It MUST NOT increment when OBJECT_METADATA is re-emitted solely due to reconnection or replay without a structural change.
+
+DML event before/after payloads MUST carry data values only. source_type, logical_type, parameters, and nullable MUST NOT be repeated per row -- they reside exclusively in OBJECT_METADATA. This mode is always active; schema_on_change MUST always be true.
+
+### 4.5.2 Schema on Reconnect (OPTIONAL, default ON)
+
+When active, the producer MUST emit the current OBJECT_METADATA event for every table active in the stream before resuming data delivery to any connecting or reconnecting consumer. These re-emitted events are session-scoped -- they MUST NOT be inserted into the durable stream and MUST NOT alter schema_version.
+
+The producer MUST maintain a current schema map (table -> current OBJECT_METADATA) in durable state and emit from this map at connection time. A consumer reading schema_on_reconnect: false MUST NOT wait for session-scoped OBJECT_METADATA -- it must rely on Schema on Each Event, which MUST be active if Schema on Reconnect is off. Cross-reference: This mode is the behavioral equivalent of Approach 1 in Section 6.4.
+
+### 4.5.3 Schema on Each Event (OPTIONAL, default OFF)
+
+When active, the producer MUST embed the full OBJECT_METADATA data payload inline within every DML event under a top-level key named _schema in the DML data object. The embedded _schema object MUST be structurally identical to the data block of a standalone OBJECT_METADATA event and MUST contain table, schema_version, primary_key, columns[], and json_schema.
+
+The DML event's dataschema CloudEvents field MUST still reference the CloudEvents id of the most recently emitted standalone OBJECT_METADATA event. The _schema embedding supplements but does not replace the dataschema reference.
+
+Note: The _schema embedding does not violate the Section 4.1 values-only constraint on before/after — it is a separate, optional top-level key alongside those fields, not within them.
+
+Key use cases: stateless consumption where the consumer process has no persistent schema cache (e.g., serverless functions, ephemeral containers); consumers that join a stream mid-session without access to start-of-connection OBJECT_METADATA events; consumers operating in Ephemeral Mode (Section 15.2). Wire overhead of embedding _schema in every DML event is significant for wide tables -- producers SHOULD document per-event overhead. A row for _schema MUST be added to the Section 5.2 Common DML Payload Fields table as: field _schema, Conditional, Present only when schema_on_each_event: true; contains full OBJECT_METADATA data payload.
+
+### 4.5.4 Schema by Reference (OPTIONAL, default OFF)
+
+When active, the dataschema CloudEvents field on DML events contains a resolvable URL to an external schema registry endpoint. The producer MUST still emit standalone OBJECT_METADATA events in the stream per Schema on Change (Section 4.5.1). Schema by Reference does not replace inline schema delivery -- it adds an external resolution path as a supplement.
+
+Primary use case: deployments backed by an external schema registry. MUST NOT be the sole schema acquisition path (see Section 4.4 Reconnect Coverage rule). A consumer that cannot reach the registry MUST fall back to stream-embedded OBJECT_METADATA events.
+
+# 5. DML Payload Structure
+
+The data field of every DML CloudEvent is owned entirely by OpenCDC. It carries the row change information in a values-only format -- type metadata is resolved from the OBJECT_METADATA schema referenced by dataschema.
+
+## 5.1 Table Identity
+
+Table identity MUST be split into discrete fields to accommodate heterogeneous sources. MySQL has no schema layer; BigQuery has no catalog concept. At minimum, name is required.
+
+```
+"table": {
+  "catalog": "ORCL",      // OPTIONAL -- database instance / catalog name
+  "schema":  "FINANCE",   // OPTIONAL -- schema / namespace (omit for MySQL)
+  "name":    "ORDERS"     // REQUIRED
+}
+```
+
+## 5.2 Common DML Payload Fields
+
+- **table**
+  - Required: MUST
+  - Description: Structured table identity object. MUST match the subject field in the CloudEvents envelope.
+
+- **primary_key**
+  - Required: MUST
+  - Description: Array of column names that constitute the CDC identity key. MUST match the primary_key declared in the referenced OBJECT_METADATA.
+
+- **before**
+  - Required: Conditional
+  - Description: Full or partial row image before the operation. MUST be null for INSERT and snapshot.READ. MUST be present (non-null) for UPDATE and DELETE. Contains only changed columns when changed_columns is present.
+
+- **after**
+  - Required: Conditional
+  - Description: Full or partial row image after the operation. MUST be null for DELETE and TRUNCATE. MUST be present (non-null) for INSERT, UPDATE, and snapshot.READ.
+
+- **changed_columns**
+  - Required: OPTIONAL
+  - Description: Array of column names that changed in an UPDATE. When present, before and after MUST contain only these columns (plus primary key columns). When absent, before and after MUST contain all columns. See Section 5.4.
+
+- **(absent column rule)**
+  - Required: --
+  - Description: A column absent from a partial before/after image MUST be interpreted as unchanged -- not as null and not as deleted. This is a MUST for all consumers. Null values are signaled exclusively via _null_columns.
+
+- **_null_columns**
+  - Required: MUST
+  - Description: Array of column names whose value is genuinely NULL in the source row. MUST be present even if empty. Columns listed here have JSON null as their value in before/after.
+
+- **_lob_overflow**
+  - Required: MUST
+  - Description: Array of column names whose LOB content was not captured. MUST be present even if empty. Columns listed here have JSON null as their value but are NOT actually null -- the content was not available to the capture layer.
+
+- **pos**
+  - Required: MUST
+  - Description: Structured position object. See Section 8.1.
+
+- **checksum**
+  - Required: OPTIONAL
+  - Description: SHA-256 of the canonical JSON serialization of the after image, hex-encoded. Consumers MAY use this to detect payload corruption.
+
+## 5.3 Value Encoding
+
+Column values in before and after MUST be encoded per the wire encoding rules defined for the column's logical_type in the OpenCDC Type System Proposal v0.2. The following are the most important rules for implementers:
+
+- **INT8, INT16, INT32, INT64, UINT8-UINT32**
+  - Wire Encoding in DML payload: JSON number. Within JSON safe integer range.
+
+- **UINT64 (MySQL BIGINT UNSIGNED)**
+  - Wire Encoding in DML payload: Exact decimal STRING always. Max value exceeds JSON safe integer range.
+
+- **DECIMAL, DECIMAL256, ORACLE_NUMBER**
+  - Wire Encoding in DML payload: Exact decimal STRING always. Preserves trailing zeros and arbitrary precision. Special values: "NaN", "Infinity", "-Infinity" as strings (PostgreSQL NUMERIC only).
+
+- **FLOAT32, FLOAT64**
+  - Wire Encoding in DML payload: JSON number. Special values: "NaN", "Infinity", "-Infinity" as strings. Negative zero as JSON -0.
+
+- **DECFLOAT16, DECFLOAT34 (IBM Db2)**
+  - Wire Encoding in DML payload: Exact decimal STRING always. Cannot be approximated as IEEE 754 binary.
+
+- **STRING, NATIONAL_STRING**
+  - Wire Encoding in DML payload: UTF-8 JSON string.
+
+- **STRING_LOB, BYTES_LOB**
+  - Wire Encoding in DML payload: UTF-8 string / Base64, or JSON null + column name in _lob_overflow.
+
+- **BYTES, BYTEA, RAW, VARBINARY**
+  - Wire Encoding in DML payload: Base64 JSON string (RFC 4648, no line breaks).
+
+- **DATE (non-Oracle)**
+  - Wire Encoding in DML payload: ISO 8601 date string: "YYYY-MM-DD". No time component.
+
+- **ORACLE_DATE**
+  - Wire Encoding in DML payload: ISO 8601 datetime: "YYYY-MM-DDTHH:MM:SS". Time component MUST always be included.
+
+- **TIMESTAMP, DATETIME**
+  - Wire Encoding in DML payload: ISO 8601 datetime string with fractional seconds per schema precision parameter.
+
+- **TIMESTAMP_TZ, DATETIMEOFFSET**
+  - Wire Encoding in DML payload: ISO 8601 with offset: "...+HH:MM". Original offset MUST be preserved. MUST NOT normalize to UTC.
+
+- **MYSQL_TIMESTAMP**
+  - Wire Encoding in DML payload: ISO 8601 datetime string. Logical_type in schema signals UTC-storage and auto-update semantics to consumers.
+
+- **INTERVAL_YM, INTERVAL_DS**
+  - Wire Encoding in DML payload: ISO 8601 duration string: "P1Y2M", "P1DT2H3M4.567890S".
+
+- **BOOLEAN**
+  - Wire Encoding in DML payload: JSON true / false / null.
+
+- **BIT, TINYINT1**
+  - Wire Encoding in DML payload: JSON 0 / 1 / null. NOT JSON boolean.
+
+- **UUID**
+  - Wire Encoding in DML payload: Hyphenated lowercase string, RFC 4122 byte order.
+
+- **GUID (SQL Server)**
+  - Wire Encoding in DML payload: Hyphenated string, SQL Server display byte order. NOT RFC 4122.
+
+- **JSON, JSONB**
+  - Wire Encoding in DML payload: Escaped JSON string. NOT a nested JSON object.
+
+- **GEOMETRY (spatial)**
+  - Wire Encoding in DML payload: OGC EWKT string with SRID: "SRID=4326;POINT(-73.98 40.74)".
+
+- **VECTOR**
+  - Wire Encoding in DML payload: JSON array of numbers. Base64 for BIT/BINARY element types.
+
+## 5.4 Partial UPDATE Images (changed_columns)
+
+Full row before/after images are expensive for wide tables, especially those with LOB columns. OpenCDC supports partial UPDATE images when the source CDC tool can identify which columns changed.
+
+```
+// Full UPDATE image (changed_columns absent -- all columns required):
+"before": { "ORDER_ID": 1001, "STATUS": "PENDING",  "AMOUNT": "99.95", "NOTES": null },
+"after":  { "ORDER_ID": 1001, "STATUS": "SHIPPED",  "AMOUNT": "99.95", "NOTES": null },
+"changed_columns": null,   // or omitted
+
+// Partial UPDATE image (changed_columns present):
+"before":          { "ORDER_ID": 1001, "STATUS": "PENDING" },
+"after":           { "ORDER_ID": 1001, "STATUS": "SHIPPED" },
+"changed_columns": ["STATUS"], // ORDER_ID always included (pk). AMOUNT and NOTES not present = not changed.
+// Consumer MUST NOT infer that absent columns are null.
+```
+
+**Partial Image Consumer Rule -- Including LOB Columns**
+When changed_columns is present: columns absent from before/after are UNCHANGED regardless of their type -- including LOB columns. A LOB column that is absent from the payload MUST be interpreted as unchanged, not as overflowed or null. Consumers MUST NOT infer the value of absent columns. LOB overflow (_lob_overflow) applies only to columns that ARE explicitly present in the payload with a null value. A column can only appear in _lob_overflow if it is present in before or after. An absent column is simply not part of this event -- its LOB status is irrelevant. Summary of null semantics for any column: (1) Present in payload + in _null_columns -> genuinely null in source. (2) Present in payload + in _lob_overflow -> content not captured (not null). (3) Absent from payload + in changed_columns -> producer error (changed columns MUST be present). (4) Absent from payload + not in changed_columns -> unchanged, ignore. When changed_columns is absent or null: before and after MUST contain all columns. Absence of any column from a full image is a producer conformance violation.
+
+## 5.5 Complete DML Payload Examples
+
+### INSERT
+
+```
+{
+  "specversion": "1.1", "id": "evt-001", "type": "com.acme.cdc.dml.INSERT",
+  "source": "//oracle-prod/ORCL/FINANCE", "subject": "FINANCE.ORDERS",
+  "dataschema": "schema-FIN-ORDERS-v2", "cdcspecversion":"0.2",
+  "cdcxid": "txn-000001", "cdctxorder": 0, "cdcpos": "000001:0",
+  "data": {
+    "table":       { "catalog":"ORCL", "schema":"FINANCE", "name":"ORDERS" },
+    "primary_key": ["ORDER_ID"],
+    "before":      null,
+    "after": {
+      "ORDER_ID":      1001,
+      "STATUS":        "PENDING",
+      "AMOUNT":        "199.99",
+      "NOTES":         null,
+      "TRACKING_CODE": null
+    },
+    "_null_columns":  ["NOTES", "TRACKING_CODE"],
+    "_lob_overflow":  [],
+    "pos": { "lsn":"000001", "source_timestamp":"2026-05-03T10:00:59Z", "lsn_offset":0, "native_position":"..." }
+  }
+}
+```
+
+### UPDATE (partial image)
+
+```
+{
+  "specversion": "1.1", "id": "evt-002", "type": "com.acme.cdc.dml.UPDATE",
+  "source": "//oracle-prod/ORCL/FINANCE", "subject": "FINANCE.ORDERS",
+  "dataschema": "schema-FIN-ORDERS-v2", "cdcspecversion":"0.2",
+  "cdcxid": "txn-000002", "cdctxorder": 0, "cdcpos": "000002:0",
+  "data": {
+    "table":           { "catalog":"ORCL", "schema":"FINANCE", "name":"ORDERS" },
+    "primary_key":     ["ORDER_ID"],
+    "changed_columns": ["STATUS", "TRACKING_CODE"],
+    "before": {
+      "ORDER_ID":      1001,
+      "STATUS":        "PENDING",
+      "TRACKING_CODE": null
+    },
+    "after": {
+      "ORDER_ID":      1001,
+      "STATUS":        "SHIPPED",
+      "TRACKING_CODE": "TRK-2026-00812"
+    },
+    "_null_columns":  [],
+    "_lob_overflow":  [],
+    "pos": { "lsn":"000002", "source_timestamp":"2026-05-03T10:05:00Z", "lsn_offset":0, "native_position":"..." }
+  }
+}
+```
+
+### DELETE
+
+```
+{
+  "specversion": "1.1", "id": "evt-003", "type": "com.acme.cdc.dml.DELETE",
+  "dataschema": "schema-FIN-ORDERS-v2", "cdcspecversion":"0.2",
+  "cdcxid": "txn-000003", "cdctxorder": 0, "cdcpos": "000003:0",
+  "data": {
+    "table":       { "catalog":"ORCL", "schema":"FINANCE", "name":"ORDERS" },
+    "primary_key": ["ORDER_ID"],
+    "before": {
+      "ORDER_ID":      1001,
+      "STATUS":        "SHIPPED",
+      "AMOUNT":        "199.99",
+      "NOTES":         null,
+      "TRACKING_CODE": "TRK-2026-00812"
+    },
+    "after":          null,
+    "_null_columns":  ["NOTES"],
+    "_lob_overflow":  [],
+    "pos": { "lsn":"000003", "source_timestamp":"2026-05-03T10:10:00Z", "lsn_offset":0, "native_position":"..." }
+  }
+}
+```
+
+# 6. Producer Contract
+
+This section defines the complete set of behavioral obligations for conforming OpenCDC producers. A producer is any system that emits OpenCDC events -- a CDC tool, a database extension, or an application-layer change publisher.
+
+## 6.1 Stream Ordering Obligations
+
+- P-ORD-1: Producers MUST emit events in source transaction log order within a single captured stream.
+
+- P-ORD-2: All events within the same source transaction MUST carry the same cdcxid value.
+
+- P-ORD-3: Within a transaction, cdctxorder MUST be 0-based and monotonically increasing. No two events in the same transaction MAY share a cdctxorder value.
+
+- P-ORD-4: The OBJECT_METADATA event for a table MUST precede any DML event for that table in the stream. This is an unconditional ordering constraint -- there is no exception for high-throughput scenarios.
+
+- P-ORD-5: A new OBJECT_METADATA event MUST be emitted after any DDL event that changes a table's column structure, and before the first subsequent DML event for that table.
+
+- P-ORD-6 (CRITICAL -- Partition Alignment): All events belonging to the same transaction (same cdcxid) MUST be emitted with the same partitionkey value. This ensures all events of a transaction land on the same Kafka partition and are therefore subject to the same ordering guarantee. A producer that distributes a single transaction across multiple partitionkey values is non-conformant. If a transaction touches rows with different primary keys, the producer MUST choose one partitionkey for the entire transaction (e.g., the primary key of the first changed row, or a transaction-level hash).
+
+- P-ORD-7 (Multi-Table TRUNCATE): When a source engine executes a single TRUNCATE statement that explicitly names multiple tables (e.g., PostgreSQL TRUNCATE table_a, table_b, table_c;), the producer MUST emit one TRUNCATE event per named table. All TRUNCATE events from the same multi-table statement MUST carry the same cdcxid value and MUST be assigned sequential cdctxorder values (0, 1, 2, ...) in the order the tables appear in the statement or in capture-layer log order when statement order is not determinable. A producer that emits TRUNCATE events for a multi-table statement with different cdcxid values is non-conformant. IMPORTANT: a multi-table TRUNCATE (user explicitly names multiple tables in one statement) is distinct from CASCADE-propagated truncation (implicit truncation of related tables via foreign key relationships). Both produce multiple TRUNCATE events sharing a cdcxid, but the mechanism differs. The multi_table field in truncate_details (Section 10.2) signals the explicit case; the cascade field signals CASCADE behavior. Propagated table enumeration is explicitly deferred to a future specification version.
+
+## 6.2 Type Fidelity Obligations
+
+- P-TYPE-1: Producers MUST populate source_type with the verbatim DDL type declaration from the source engine. Normalization, aliasing, or expansion of source types is non-conformant.
+
+- P-TYPE-2: Producers MUST populate logical_type with a value from the OpenCDC canonical vocabulary (Type System Proposal v0.2). The mapping from source_type to logical_type MUST be deterministic: the same source_type from the same engine always produces the same logical_type.
+
+- P-TYPE-3: Producers MUST encode DML column values per the wire encoding rules for the column's logical_type. Encoding in a format inconsistent with the declared logical_type is a conformance violation.
+
+- P-TYPE-4: Producers MUST NOT silently truncate, round, or reduce the precision of any value. If a value cannot be captured at full source precision, the producer MUST emit an error or omit the column with explicit flagging -- not silently reduce precision.
+
+## 6.3 LOB Handling Obligations
+
+- P-LOB-1: Producers MUST distinguish between a genuinely null LOB column and a LOB column whose content was not captured. Genuinely null columns MUST appear in _null_columns. Uncaptured LOB columns MUST appear in _lob_overflow. Both have JSON null as the value field -- the arrays are the only way to distinguish them.
+
+- P-LOB-2: Both _null_columns and _lob_overflow MUST be present in every DML payload, even when empty.
+
+## 6.4 Consumer Reconnection Obligations
+
+Producers MUST support at least one of the following reconnection behaviors. The conformance rules governing which approaches are required versus optional are defined in Section 4.4 (Conformance Rule -- Reconnect Coverage) and Section 4.5.2. Approach 1 (Schema on Reconnect) MUST be active unless Schema on Each Event (Section 4.5.3) is active and declared in STREAM_METADATA. A producer MAY support both approaches simultaneously.
+
+### Approach 1 -- Schema Re-Emission on Connection (Schema on Reconnect Mode)
+
+When any consumer connection is established (initial or reconnect), the producer MUST emit current OBJECT_METADATA events for all tables that are active in the stream before resuming data delivery from the consumer's requested start position.
+
+- Re-emitted OBJECT_METADATA events are session-scoped. They MUST NOT be inserted into the durable stream.
+
+- The producer MUST maintain a current schema map (table -> current OBJECT_METADATA) and emit from this map at connection time.
+
+- If the current schema version differs from the last version the consumer acknowledged, the consumer will detect the mismatch via schema_version and can request full resync if needed.
+
+### Approach 2 -- Schema Within Replay Window (Recommended Enhancement)
+
+When a consumer resumes from a saved cdcpos value, replay MUST begin at or before the most recent OBJECT_METADATA event for each in-scope table that was current at that position.
+
+- The producer MUST locate the most recent OBJECT_METADATA event for each table preceding the resume position and begin replay from there.
+
+- The consumer receives its schema before its first data event, regardless of resume position.
+
+- Approach 2 MUST be combined with Approach 1 for initial connections (no saved position).
+
+## 6.5 Interoperability Guarantee
+
+A conforming producer MUST emit events that a conforming consumer can apply without:
+
+- Knowledge of the originating CDC tool or vendor
+
+- Knowledge of the source database engine beyond what is expressed in source_type and logical_type
+
+- Custom transformation logic, field renaming, or type coercion
+
+- Access to any external registry, database, or service
+
+This is the normative statement of the specification's core interoperability requirement (see the OpenCDC User Stories document for the motivating use cases). Any event that requires consumer-side vendor knowledge to decode is non-conformant regardless of whether other fields are correctly populated.
+
+# 7. Consumer Contract
+
+The behavioral obligations a consumer adopts are non-normative for this specification, which governs producer behavior (see Document Authority and Scope). A producer's job is to emit a stream that a consumer can read and interpret with full fidelity; how a given consumer chooses to apply that stream depends on the service level it targets. The consumer obligations formerly stated here -- ordering, schema evolution, idempotency, LOB handling, validation, and TRUNCATE handling -- are collected as service-level guidance in Appendix A (Consumer Conformance, Obligations & Service-Level Guidance).
+
+# 8. Position and Replay Semantics
+
+## 8.1 Structured Position Object
+
+Every DML, DDL, and HEARTBEAT event MUST include a pos object in its data payload. The pos object provides structured, source-agnostic positioning for stream resume and replay. It MUST NOT be the sole location of position information -- cdcpos in the CloudEvents envelope provides the opaque resume handle visible to infrastructure.
+
+```
+"pos": {
+  "lsn":             "0000012C000004D2",   // hex-encoded log sequence number
+  "source_timestamp":"2026-03-22T14:23:00.998Z",  // commit time, ISO 8601
+  "lsn_offset":      14,                   // disambiguator within this LSN; 0-based
+  "native_position": "G-AQAAADIKAAAAA..."  // opaque source-specific value for replay
+}
+```
+
+- **lsn**
+  - Required: MUST
+  - Description: Hex-encoded log sequence number normalized to a comparable string. MUST be monotonically increasing within the stream. Used for ordering and deduplication.
+
+- **source_timestamp**
+  - Required: MUST
+  - Description: ISO 8601 timestamp of the source commit. MUST be the database commit time, not capture time. Matches the CloudEvents time field.
+
+- **lsn_offset**
+  - Required: MUST
+  - Description: Non-negative integer. Disambiguates multiple events committed at the same LSN position -- for example, multiple row changes within a single database transaction that share one log record. lsn_offset is 0-based and monotonically increasing within a given lsn value. (pos.lsn, pos.lsn_offset) together form a total order for all events at the payload level. DISTINCT from the CloudEvents sequence envelope field -- see Section 3.3 for disambiguation.
+
+- **native_position**
+  - Required: SHOULD
+  - Description: Opaque, source-specific position value for replay. Consumers MUST NOT parse this field. It is passed back to the producer verbatim when resuming. Examples: Oracle SCN+XID string, PostgreSQL pg_lsn, MySQL GTID.
+
+## 8.2 Replay Rules
+
+- R-POS-1: Consumers MUST persist the (pos.lsn, pos.lsn_offset) pair of the last successfully applied event as their structured resume position. This pair, combined with the cdcpos envelope value, constitutes the complete resume state. Consumers MUST persist cdcpos as the primary replay handle (per R-POS-3); (pos.lsn, pos.lsn_offset) is the structured equivalent for consumer-side ordering logic and gap detection.
+
+- R-POS-0 (Ordering Scope): Event ordering is guaranteed within a partitionkey. All events of a single transaction share the same partitionkey (P-ORD-6), so transaction ordering is always preserved within one Kafka partition. Events from different transactions with different partitionkeys MAY arrive out of order relative to each other -- this is expected and correct. Consumers requiring total global ordering across all transactions MUST use the CloudEvents sequence envelope field (Section 3.3), which provides a producer-assigned global monotonic counter across all tables and partitions. The CloudEvents sequence field is distinct from pos.lsn_offset (which disambiguates events within a single LSN) and from cdctxorder (which orders events within a single transaction). The CloudEvents sequence field is not required for correctness of single-transaction or single-row operations, but is required for any consumer that must establish a total order across independently partitioned tables.
+
+- R-POS-2: On resume, consumers MUST provide their saved cdcpos value to the producer. The producer MUST resume delivery from a position at or before the schema event preceding the consumer's saved position (per Section 6.4, Approach 2), ensuring the consumer always receives its schema before data.
+
+- R-POS-3: The cdcpos value from the CloudEvents envelope is the authoritative resume handle. The pos object within the payload provides structured data for consumer-side ordering logic. Both MUST be maintained.
+
+- R-POS-4: Producers MUST guarantee that replay from a saved position produces events in the same order as the original delivery. Event reordering during replay is a conformance violation.
+
+- R-POS-5: At-least-once delivery is the minimum guarantee. Producers MAY emit duplicate events during replay. Consumers handle duplicates per Appendix A.3 (Idempotency).
+
+**Replay Guarantee Summary**
+Conformant replay MUST satisfy all three of the following:
+1. BEGINS BEFORE SCHEMA: Replay begins at or before the OBJECT_METADATA event that was current for each in-scope table at the resume position. The consumer always receives its schema before its first data event.
+2. PRESERVES ORDERING: Events are replayed in the same (pos.lsn, pos.lsn_offset) order as their original delivery. A producer that reorders events during replay is non-conformant. The CloudEvents sequence value MAY differ on replay from the original delivery value -- consumers MUST NOT depend on sequence value identity across sessions. The deduplication key (source, id) is the only cross-session event identity guarantee (see Section 11.1).
+3. PRESERVES IDs: Each replayed event carries its original CloudEvents id (UUID v4 assigned at creation). Generating new IDs during replay breaks consumer deduplication and is a producer conformance violation.
+
+## 8.3 Transaction Boundaries
+
+OpenCDC uses three distinct ordering fields serving different scopes. All three may be present simultaneously and MUST NOT be conflated. The CloudEvents sequence field (Section 3.3) provides global session-level total ordering; it is not included in the transaction boundary table below because it operates independently of transaction grouping.
+
+Transaction identity is available at two layers by design:
+
+- **Transaction grouping**
+  - Field: cdcxid
+  - Layer: CloudEvents envelope
+  - Use: Infrastructure routers and stream-processing topologies -- group by transaction without payload deserialization
+
+- **Event order within transaction**
+  - Field: cdctxorder
+  - Layer: CloudEvents envelope
+  - Use: Ordering and gap detection without payload deserialization
+
+- **Stream resume**
+  - Field: cdcpos
+  - Layer: CloudEvents envelope
+  - Use: Passed to producer on reconnect. Opaque.
+
+- **Structured positioning**
+  - Field: pos.lsn + pos.lsn_offset
+  - Layer: Payload data
+  - Use: Consumer-side ordering, deduplication, monitoring
+
+- **Source-native replay**
+  - Field: pos.native_position
+  - Layer: Payload data
+  - Use: Passed to source for precise log replay. Do not parse.
+
+- T-COMPLETE: A transaction is complete when (a) the first event of a new cdcxid is observed, OR (b) a HEARTBEAT is received after all events of the transaction have been delivered. Producers MUST emit a HEARTBEAT within the configured heartbeat_interval_seconds after any transaction that is followed by an idle period. This guarantees that consumers are never left waiting indefinitely for a transaction completion signal. Consumers MUST NOT commit a transaction until T-COMPLETE is satisfied by one of the two conditions above.
+
+- T-NOINTERLEAVE: Events from different transactions MUST NOT be interleaved in the stream. All events of transaction cdcxid=A MUST be delivered before any event of transaction cdcxid=B, for any A that commits before B. A producer that interleaves transaction events is non-conformant.
+
+- T-ORDER: Within a transaction, events MUST be delivered in cdctxorder sequence (0, 1, 2, ...). Gaps in cdctxorder are a producer conformance error. Consumers detecting a gap MUST surface an error and MUST NOT apply subsequent events until the gap is resolved.
+
+**No Transaction Completion Marker**
+OpenCDC does not define an explicit COMMIT event type. Transaction completion is inferred: a consumer that has received all events for a given cdcxid (detected by receiving the first event of the next cdcxid, or by a HEARTBEAT after a transaction) may commit the transaction atomically. Producers MUST emit all events of a transaction before emitting any event of a subsequent transaction (i.e., transactions MUST NOT be interleaved in the stream). This guarantee makes transaction boundary detection reliable from cdcxid alone.
+
+**TRUNCATE and Transaction Boundaries -- Engine-Specific Behavior**
+TRUNCATE has materially different transactional properties depending on the source database engine, and producers MUST handle cdcxid assignment accordingly.
+
+Transactional TRUNCATE (PostgreSQL, SQL Server): TRUNCATE is a fully transactional operation that participates in the enclosing transaction and can be rolled back. The TRUNCATE event MUST carry the source transaction's real cdcxid. A TRUNCATE can appear mid-transaction alongside INSERT, UPDATE, and DELETE events -- all events share the same cdcxid and sequential cdctxorder values. Consumers MUST expect that DML events may appear after a TRUNCATE within the same cdcxid; this is a valid transactional sequence and MUST be applied in cdctxorder order.
+
+Non-Transactional TRUNCATE (Oracle, MySQL/MariaDB): TRUNCATE is a DDL statement that causes an implicit COMMIT of any open transaction before executing and cannot be rolled back. Because it does not belong to a real source transaction, a producer capturing an Oracle or MySQL TRUNCATE MUST assign a synthetic cdcxid value. The synthetic value MUST be: (a) unique within the stream, (b) stable across replay of the same event (same synthetic cdcxid on replay), and (c) documented by the producer implementation. Non-transactional TRUNCATE events will never appear alongside other DML events in the same cdcxid -- they are always solitary single-event synthetic transactions.
+
+## 8.4 Sequence Discontinuity -- Producer Obligations and Consumer Handling
+
+Under normal operation, the CloudEvents sequence counter is monotonically increasing within a session and pos.lsn values are monotonically increasing within a stream. Several real-world operational conditions break these guarantees. This section defines how producers MUST signal discontinuities and how consumers MUST respond.
+
+### 8.4.1 Sequence Continuity Declaration (STREAM_METADATA)
+
+Every STREAM_METADATA event MUST include a sequence_continuity field in its data object declaring the producer's continuity guarantee for this session. Valid values:
+
+- **"guaranteed"**
+  - Meaning: Producer guarantees pos.lsn values are monotonically increasing from all prior sessions on this stream.
+  - Consumer Obligation: Consumer MAY compare pos.lsn values across session boundaries for ordering purposes.
+
+- **"best_effort"**
+  - Meaning: Producer believes LSN continuity holds but cannot guarantee it -- e.g., after a non-switchover restart.
+  - Consumer Obligation: Consumer SHOULD treat cross-session pos.lsn comparisons as advisory only. MUST NOT fail on a non-increasing pos.lsn value.
+
+- **"reset"**
+  - Meaning: Producer declares pos.lsn values from this session are NOT comparable to values from any prior session. Counter restarts.
+  - Consumer Obligation: Consumer MUST NOT compare pos.lsn across the session boundary. MUST treat sequence counter as restarted. MUST NOT reject events solely because pos.lsn is lower than a previously seen value.
+
+### 8.4.2 In-Stream Discontinuity Signaling (HEARTBEAT)
+
+When a sequence or LSN discontinuity occurs mid-session, the producer MUST signal it via the next HEARTBEAT event using two boolean fields: lsn_reset (true if pos.lsn values after this HEARTBEAT are not comparable to values before it) and sequence_reset (true if the CloudEvents sequence counter has restarted or jumped non-monotonically). A consumer receiving a HEARTBEAT with lsn_reset: true or sequence_reset: true MUST apply the same rules as for sequence_continuity: "reset" in STREAM_METADATA, from the point of the HEARTBEAT forward.
+
+### 8.4.3 Canonical Discontinuity Scenarios
+
+Scenario 1 -- Database migration or physical source change: When the CDC producer continues streaming after the source database is migrated to a new physical host, the new instance may produce LSN values that are non-comparable with the previous instance. Producer MUST set sequence_continuity: "reset" in the first STREAM_METADATA after migration. Consumer MUST treat the first post-signal event as establishing a new LSN baseline and save a new cdcpos checkpoint immediately.
+
+Scenario 2 -- High-availability failover (primary/standby promotion): Producer MUST set sequence_continuity: "best_effort" or "reset" depending on whether LSN continuity across the failover can be verified. If verification is not possible, MUST use "reset". Producers MUST NOT silently continue with "guaranteed" after a detected failover.
+
+Scenario 3 -- Binary log rotation without GTID (MySQL): Producer MUST normalize pos.lsn to a monotonically increasing value across binlog rotation (e.g., by encoding the binlog file sequence number as high bytes of the hex LSN string). If the producer cannot guarantee this normalization, it MUST set sequence_continuity: "reset". MySQL GTIDs provide a more robust position space and are RECOMMENDED for OpenCDC-conformant MySQL producers.
+
+Scenario 4 -- New tables or columns added to capture scope on reconnect: Producer MUST emit these OBJECT_METADATA events with sequence values higher than the last event of the prior session if determinable. If not, MUST emit with sequence_continuity: "reset". Consumer MUST accept OBJECT_METADATA events with any sequence value after a reconnect.
+
+Scenario 5 -- Multi-master or active-active source topology: Producer MUST set sequence_continuity: "best_effort" for streams from multi-master topologies. The CloudEvents sequence counter is the authoritative total order in this case -- pos.lsn values are per-node and MUST NOT be compared across nodes. Producer SHOULD include originating node identifier in pos.native_position.
+
+### 8.4.4 What the Specification Does Not Govern
+
+The following are intentionally outside scope: specific LSN normalization algorithms for individual database engines; operational procedures for verifying LSN continuity after failover; monitoring thresholds for acceptable LSN lag or gap rates; vendor-specific GTID formats, binlog file naming, or SCN semantics. The specification defines the output contract and what producers must declare. The implementation path to satisfying that contract is the producer implementer's responsibility.
+
+# 9. DDL Events
+
+DDL events are first-class CloudEvents that carry schema change operations transactionally ordered with DML events in the same stream. Routing schema changes to a channel separate from the data stream would break the transactional correlation between a schema change and the data changes that depend on it; OpenCDC keeps both in one ordered stream.
+
+## 9.1 DDL Payload Structure
+
+```
+{
+  "specversion":    "1.1",
+  "id":             "a1b2c3d4-0000-0000-0000-000000000099",
+  "source":         "//oracle-prod.acme.com/ORCL/FINANCE",
+  "subject":        "FINANCE.ORDERS",
+  "type":           "com.acme.cdc.ddl.ALTER",
+  "time":           "2026-03-22T15:00:00.000Z",
+  "datacontenttype":"application/json",
+  "cdcspecversion": "0.2",
+  "cdcxid":         "1510528009.5.14.0001",
+  "cdcpos":         "0000012C000005A1:1",
+  "data": {
+    "table": { "catalog": "ORCL", "schema": "FINANCE", "name": "ORDERS" },
+    "ddl": {
+      "statement":          "ALTER TABLE FINANCE.ORDERS ADD (TRACKING_CODE VARCHAR2(50))",
+      "statement_truncated": false         // true if DDL was too long to include fully
+    },
+    "pos": {
+      "lsn":             "0000012C000005A1",
+      "source_timestamp":"2026-03-22T15:00:00.000Z",
+      "lsn_offset":      1,
+      "native_position": "G-AQAAADIKBBBBB..."
+    }
+  }
+}
+```
+
+Following this DDL event, the producer MUST emit a new OBJECT_METADATA event (schema_version incremented) before the next DML event for FINANCE.ORDERS. See Section 4.1 for the mandatory ordering rule.
+
+# 10. Lifecycle Events
+
+## 10.1 HEARTBEAT
+
+HEARTBEAT events MUST be emitted periodically during idle periods (no DML changes occurring). They solve the fundamental monitoring problem of distinguishing a silent stream (no changes) from a broken stream (capture has failed). Producers MUST emit a HEARTBEAT at least every N seconds during idle periods, where N is a configurable parameter with a default of 30 seconds.
+
+```
+{
+  "specversion":    "1.1",
+  "id":             "hb-20260322-142500-001",
+  "source":         "//oracle-prod.acme.com/ORCL/FINANCE",
+  "type":           "com.acme.cdc.meta.HEARTBEAT",
+  "time":           "2026-03-22T14:25:00.000Z",
+  "datacontenttype":"application/json",
+  "cdcspecversion": "0.2",
+  "cdcpos":         "0000012C000004D2:14",    // last confirmed position
+  "data": {
+    "source_lag_ms":   0,
+    "capture_active":  true,
+    "lsn_reset":       false,
+    "sequence_reset":  false,
+    "pos": {
+      "lsn":             "0000012C000004D2",
+      "source_timestamp":"2026-03-22T14:24:58.100Z",
+      "lsn_offset":      14
+    }
+  }
+}
+```
+
+## 10.2 TRUNCATE
+
+### 10.2.1 Classification and Minimum Contract
+
+TRUNCATE is a DDL-adjacent operation that OpenCDC formally classifies as dml.TRUNCATE -- a DML-category event -- to preserve its position in the transactional event stream alongside INSERT, UPDATE, and DELETE. This classification resolves a real ambiguity: TRUNCATE does not fit cleanly into DDL (because it changes data, not schema) or DML (because it carries no before/after image). A TRUNCATE event denotes the deletion of all rows in the named table; the corresponding consumer obligation is stated in Appendix A.6. In a TRUNCATE event both before and after MUST be null. TRUNCATE events do not generate a new OBJECT_METADATA schema version -- a TRUNCATE does not alter the table's column structure. The mandatory OBJECT_METADATA ordering rule (Section 4.1) applies: OBJECT_METADATA MUST have been emitted before the TRUNCATE event, but the TRUNCATE itself does not trigger a new schema version.
+
+### 10.2.2 Transactional vs. Non-Transactional TRUNCATE
+
+TRUNCATE has fundamentally different transactional properties by engine. PostgreSQL and SQL Server: TRUNCATE is transactional, participates in the enclosing transaction, can be rolled back, and is WAL-logged or transaction-logged. The TRUNCATE event carries the real source transaction cdcxid. DML events (INSERT, UPDATE, DELETE) MAY appear after a TRUNCATE within the same cdcxid -- consumers MUST apply all events in cdctxorder sequence without assuming a TRUNCATE terminates the transaction. Oracle and MySQL/MariaDB: TRUNCATE is DDL. It causes an implicit COMMIT before executing and cannot be rolled back. Because there is no enclosing source transaction, producers MUST assign a synthetic cdcxid to these TRUNCATE events. The synthetic cdcxid MUST be unique, stable across replay, and documented by the producer. These events will never co-occur with DML events in the same cdcxid. See Section 8.3 for the full transaction boundary rules for both cases.
+
+### 10.2.3 Multi-Table TRUNCATE
+
+PostgreSQL and certain other engines support a single TRUNCATE statement that explicitly names multiple tables (e.g., TRUNCATE table_a, table_b, table_c;). For multi-table TRUNCATE, producers MUST emit one TRUNCATE event per named table. All events MUST share the same cdcxid and MUST be assigned sequential cdctxorder values (0, 1, 2, ...) per P-ORD-7. Multi-table TRUNCATE (explicit, single SQL statement) is distinct from CASCADE-propagated truncation (implicit, triggered by foreign key relationships). Both produce multiple TRUNCATE events sharing a cdcxid, but they are different mechanisms with different consumer implications. The multi_table flag in truncate_details signals the explicit case; the cascade flag signals CASCADE behavior.
+
+### 10.2.4 Payload Structure
+
+TRUNCATE events carry the standard DML payload envelope fields. primary_key MUST be populated. before and after MUST both be null. _null_columns and _lob_overflow MUST be present and MUST be empty arrays. The pos object MUST be populated per Section 8.1. The optional truncate_details object (Section 10.2.5) MAY be present when the producer can observe execution-time semantics from the source engine.
+
+```
+// -- PostgreSQL: TRUNCATE FINANCE.AUDIT_LOG CASCADE RESTART IDENTITY; --
+{
+  "specversion":    "1.1",
+  "id":             "d4e5f6a7-0000-0000-0000-000000000042",
+  "source":         "//pg-prod.acme.com/sales",
+  "subject":        "FINANCE.AUDIT_LOG",
+  "type":           "com.acme.cdc.dml.TRUNCATE",
+  "time":           "2026-05-10T09:00:00.000Z",
+  "datacontenttype":"application/json",
+  "dataschema":     "schema-AUDIT-LOG-v1",
+  "cdcspecversion": "0.4",
+  "cdcxid":         "txn-00441820",
+  "cdctxorder":     0,
+  "cdcpos":         "0000001A000007B2:0",
+  "data": {
+    "table":         { "catalog": "sales", "schema": "FINANCE", "name": "AUDIT_LOG" },
+    "primary_key":   ["LOG_ID"],
+    "before":        null,
+    "after":         null,
+    "_null_columns": [],
+    "_lob_overflow": [],
+    "truncate_details": {
+      "cascade":        true,
+      "sequence_reset": true,
+      "multi_table":    false
+    },
+    "pos": {
+      "lsn":              "0000001A000007B2",
+      "source_timestamp": "2026-05-10T09:00:00.000Z",
+      "lsn_offset":       0,
+      "native_position":  "0/1A0007B2"
+    }
+  }
+}
+```
+
+```
+// -- Oracle: TRUNCATE TABLE FINANCE.AUDIT_LOG; (non-transactional, synthetic cdcxid) --
+{
+  "specversion":    "1.1",
+  "id":             "a1b2c3d4-0000-0000-0000-000000000099",
+  "source":         "//oracle-prod.acme.com/ORCL/FINANCE",
+  "subject":        "FINANCE.AUDIT_LOG",
+  "type":           "com.acme.cdc.dml.TRUNCATE",
+  "time":           "2026-05-10T09:00:05.000Z",
+  "datacontenttype":"application/json",
+  "dataschema":     "schema-AUDIT-LOG-v1",
+  "cdcspecversion": "0.4",
+  "cdcxid":         "truncate:FINANCE.AUDIT_LOG:0000001A00000900",
+  "cdctxorder":     0,
+  "cdcpos":         "0000001A00000900:0",
+  "data": {
+    "table":         { "catalog": "ORCL", "schema": "FINANCE", "name": "AUDIT_LOG" },
+    "primary_key":   ["LOG_ID"],
+    "before":        null,
+    "after":         null,
+    "_null_columns": [],
+    "_lob_overflow": [],
+    "truncate_details": {
+      "cascade":        "not_applicable",
+      "sequence_reset": "not_applicable",
+      "multi_table":    false
+    },
+    "pos": {
+      "lsn":              "0000001A00000900",
+      "source_timestamp": "2026-05-10T09:00:05.000Z",
+      "lsn_offset":       0,
+      "native_position":  "3847264.1.0"
+    }
+  }
+}
+```
+
+### 10.2.5 The truncate_details Object
+
+truncate_details is an OPTIONAL object within the TRUNCATE event's data payload. It SHOULD be populated by producers when the source engine exposes the relevant execution-time semantics at the capture layer. It MUST be omitted when the producer cannot reliably determine the values -- producers MUST NOT fabricate or assume flag values. An absent truncate_details is always valid; a truncate_details with incorrect values is a conformance violation.
+
+**cascade**
+Type: true | false | "not_applicable" | "unknown". Whether the TRUNCATE cascaded to related tables via foreign key relationships. true means CASCADE was active and propagated to one or more related tables. false means RESTRICT was active or CASCADE was not specified and did not propagate. "not_applicable" means the source engine does not support cascading truncation as a concept. "unknown" means the engine supports CASCADE but the producer could not determine from the capture layer whether it was active. Engine guidance: PostgreSQL: true (TRUNCATE ... CASCADE) or false (TRUNCATE ... RESTRICT or default -- RESTRICT is the default). Oracle: always "not_applicable". MySQL/MariaDB: always "not_applicable". SQL Server: always "not_applicable". IBM Db2: always "not_applicable".
+
+**sequence_reset**
+Type: true | false | "not_applicable" | "unknown". Whether the table's identity, auto-increment, or sequence counter was reset as part of this TRUNCATE. true means the counter was reset to its initial value. false means the counter was preserved. "not_applicable" means the source engine has no table-attached identity or sequence concept (sequences are independent objects, not column properties). "unknown" means the engine supports identity reset but the producer could not determine the actual behavior. DISAMBIGUATION: This field reuses the name sequence_reset that also appears in HEARTBEAT events (Section 10.1). These are DISTINCT concepts: HEARTBEAT.sequence_reset signals a discontinuity in the CloudEvents stream-level sequence counter; truncate_details.sequence_reset signals a reset of the source table's identity or auto-increment column counter. Implementations MUST NOT conflate these two fields. Engine guidance: PostgreSQL: true (TRUNCATE ... RESTART IDENTITY) or false (TRUNCATE ... CONTINUE IDENTITY or default -- CONTINUE IDENTITY is the default). MySQL/MariaDB: always true -- MySQL TRUNCATE always resets AUTO_INCREMENT to the column's defined start value; there is no option to suppress this. Oracle: always "not_applicable" -- sequences are independent schema objects with no connection to TRUNCATE TABLE. SQL Server: false -- TRUNCATE TABLE does not reset IDENTITY columns and there is no option to trigger a reset via TRUNCATE. IBM Db2: false -- TRUNCATE TABLE does not reset GENERATED ALWAYS or GENERATED BY DEFAULT identity column values.
+
+**multi_table**
+Type: true | false. Whether this TRUNCATE event is one of multiple TRUNCATE events produced from a single source SQL statement that explicitly named multiple tables. true means this event shares its cdcxid with other TRUNCATE events from the same statement. false means this TRUNCATE statement named only this one table. This field signals the explicit multi-table case only and does NOT indicate CASCADE-propagated implicit truncation -- see the cascade field for that.
+
+**Deferred: propagated_tables**
+The enumeration of tables that were implicitly truncated via CASCADE (a propagated_tables array) is explicitly deferred to a future specification version. Producers MUST NOT include a propagated_tables field in truncate_details in v0.4 conformant payloads. Consumers receiving a truncate_details object with an unrecognized field MUST apply standard closed-world rejection per C-VAL-2.
+
+**Flag Value Summary**
+cascade -- true: CASCADE was active; false: RESTRICT was active or default; "not_applicable": engine has no CASCADE truncation concept; "unknown": engine supports it but producer could not determine from log. sequence_reset -- true: counter was reset; false: counter was preserved; "not_applicable": engine has no table-attached identity/sequence concept; "unknown": engine supports it but producer could not determine from log. multi_table -- true: one of N tables in a single explicit statement; false: single-table statement. (multi_table does not use "not_applicable" or "unknown" -- it is always a deterministic boolean.)
+
+### 10.2.6 Schema Registry and Closed-World Note
+
+The truncate_details object is a defined, versioned payload field in the OpenCDC specification. Its presence in a TRUNCATE event's data payload does not constitute an "unrecognized field" under C-VAL-2 -- conformant consumers that have implemented the full OpenCDC specification will recognize it by definition. The additionalProperties: false enforcement in C-VAL-2 applies to the before/after row value objects governed by the table's json_schema in OBJECT_METADATA, not to the top-level fields of the TRUNCATE data payload, which are governed by the OpenCDC specification directly. Consumers that implement only the minimum interoperability profile and have not implemented TRUNCATE support MAY encounter truncate_details as an unknown structure; such consumers SHOULD ignore the field per C-TRUNC-3 rather than reject the event.
+
+## 10.3 SNAPSHOT (Initial Load)
+
+Initial load events use type com.{org}.cdc.snapshot.READ. They carry the same before/after structure as DML events: before MUST be null; after MUST contain the full row. SNAPSHOT events MUST NOT be mixed with DML events in the same transaction group -- they MUST use a distinct cdcxid value (e.g., "snapshot:{table}:{batch_id}"). Consumers that implement different processing logic for bulk load vs. incremental apply can branch on the event type.
+
+## 10.4 STREAM_METADATA
+
+STREAM_METADATA events carry stream-level information and MUST be emitted at the start of every new consumer session, before any OBJECT_METADATA or DML events. They provide the consumer with producer identity, spec version, and stream configuration.
+
+```
+{
+  "type": "com.acme.cdc.meta.STREAM_METADATA",
+  "data": {
+    "producer":        "Acme CDC Tool 1.0",
+    "opencdc_version": "0.2",
+    "source_db":       "Oracle 23ai",
+    "capture_mode":    "logminer",
+    "tables":          ["FINANCE.ORDERS", "FINANCE.AUDIT_LOG"],
+    "heartbeat_interval_seconds": 30,
+    "schema_delivery": {
+      "schema_on_change":       true,
+      "schema_on_reconnect":    true,
+      "schema_on_each_event":   false,
+      "schema_by_reference":    false
+    },
+    "sequence_continuity":        "guaranteed"
+  }
+}
+```
+
+# 11. Idempotency and Deduplication
+
+OpenCDC guarantees at-least-once delivery. Duplicate events are an expected condition in failure and reconnect scenarios. Both producers and consumers have obligations.
+
+## 11.1 Deduplication Key
+
+OpenCDC uses two distinct identity mechanisms that serve different purposes. Conflating them is a common implementation error:
+
+- **(source, id)**
+  - Purpose: Event identity
+  - Used For: Deduplication -- have I seen this event before?
+  - Behavior During Replay: MUST remain identical. Regenerating id during replay breaks deduplication.
+
+- **cdcpos**
+  - Purpose: Stream position
+  - Used For: Replay -- where do I resume from?
+  - Behavior During Replay: Points to a position in the durable stream. Consumers save and restore this value.
+
+- **(pos.lsn, pos.lsn_offset)**
+  - Purpose: Structured position
+  - Used For: Ordering and gap detection within the consumer
+  - Behavior During Replay: Monotonically increasing within a stream. Used for consumer-side ordering logic.
+
+No two conformant events from the same source may share the same id. A consumer that receives (source=A, id=X) twice MUST apply it exactly once and MUST silently discard the duplicate.
+
+## 11.2 Producer Obligations for Idempotency
+
+- Producers MUST assign a stable UUID v4 id to each event at creation time.
+
+- During replay, producers MUST re-emit events with their original id values. Generating new IDs during replay breaks consumer deduplication.
+
+- Producers SHOULD persist event IDs in durable storage before emitting, so that a producer crash and restart does not result in duplicate events with different IDs for the same source operation.
+
+# 12. Transport Bindings
+
+CloudEvents defines two content modes. OpenCDC supports both. Transport binding is an infrastructure decision that does not affect payload compatibility. A stream that is conformant in structured mode is also conformant in binary mode -- the same events, different wire framing.
+
+- **Structured mode**
+  - Description: Envelope + data serialized together as one JSON object. All CloudEvents attributes and extension attributes appear as top-level JSON keys alongside "data".
+  - Best For: Storage, replay, HTTP webhooks, AWS EventBridge, GCP Pub/Sub, Azure Event Grid, file-based streams. Simplest for new consumers -- one JSON blob to parse.
+
+- **Binary mode**
+  - Description: CloudEvents attributes as message headers; data as the message body. cdcxid and cdctxorder are headers.
+  - Best For: Kafka and similar header-aware brokers -- consumers can filter on headers without deserializing the body. A stream-processing topology grouping events by transaction can do so purely from headers. Lower overhead; requires CloudEvents-aware consumer library or header parsing.
+
+Arrow Flight is a third transport option for implementations where databases emit OpenCDC events directly over gRPC/TLS. In Arrow Flight mode, OpenCDC events are carried in Arrow record batches. The event envelope fields map to Arrow schema metadata; the data payload maps to Arrow record columns. The full payload specification is identical -- only the wire framing changes.
+
+# 13. Observability
+
+OpenCDC defines optional fields to support distributed tracing and event correlation across complex pipeline topologies. These fields are OPTIONAL for producers but RECOMMENDED for any deployment where events flow through more than one processing stage.
+
+## 13.1 Trace Context
+
+- **trace_id**
+  - Location: CloudEvents extension attribute
+  - Description: W3C Trace Context trace ID (hex string). Propagated unchanged from the source capture event through every processing stage. Enables end-to-end tracing from database commit to target apply in distributed tracing systems (Jaeger, Zipkin, OpenTelemetry).
+
+- **correlation_id**
+  - Location: CloudEvents extension attribute or data payload
+  - Description: Business-level correlation identifier. Set by the application that originated the database change (e.g., an order ID, a session ID). Propagated from the source database transaction metadata when available.
+
+- **source_lag_ms**
+  - Location: HEARTBEAT data payload
+  - Description: Milliseconds between the source database commit timestamp and the current wall-clock time at the capture layer. Provides lag visibility without external monitoring queries.
+
+```
+// DML event with observability fields:
+{
+  "specversion":    "1.1",
+  "id":             "7f3a2b10-...",
+  "type":           "com.acme.cdc.dml.INSERT",
+  "dataschema":     "schema-ORDERS-v2",
+  "cdcspecversion": "0.2",
+  "cdcxid":         "txn-001",
+  "cdcpos":         "000001:0",
+  "trace_id":      "4bf92f3577b34da6a3ce929d0e0e4736",   // W3C trace context
+  "correlationid":  "order-cart-88291",                   // business correlation
+  "data": { ... }
+}
+```
+
+# 14. Security
+
+OpenCDC defines security requirements at the transport and access control layers. These requirements apply to all conformant implementations regardless of transport binding.
+
+## 14.1 Transport Security
+
+- S-TLS-1: All OpenCDC stream connections MUST use TLS 1.2 or higher. Unencrypted connections are non-conformant for any deployment outside of a trusted private network segment.
+
+- S-TLS-2: Producers MUST NOT transmit events containing sensitive column data over unencrypted connections. TLS termination at a proxy does not satisfy this requirement if the segment between the database and the proxy is unencrypted.
+
+- S-TLS-3: Certificate validation MUST be enforced on both producer and consumer sides. Self-signed certificates MAY be used in development environments but MUST NOT be used in production without explicit operator override.
+
+## 14.2 Authentication
+
+- S-AUTH-1: Producers and consumers MUST authenticate each other before stream establishment. Mutual TLS (mTLS) or token-based authentication (OAuth 2.0 bearer token, API key) are conformant mechanisms.
+
+- S-AUTH-2: Credentials MUST NOT be embedded in event payloads or CloudEvents extension attributes.
+
+## 14.3 Authorization
+
+- S-AUTHZ-1: Producers SHOULD implement table-level access control. A consumer connection SHOULD only receive events for tables the authenticated consumer is authorized to access. Emitting events for unauthorized tables to a connected consumer is a security violation.
+
+- S-AUTHZ-2: Producers SHOULD support column-level masking or exclusion for columns containing PII or sensitive data, configured per consumer identity. Masked columns MUST appear in the OBJECT_METADATA schema as their original source_type but with a masking indicator, and MUST emit a sentinel value (e.g., null or a fixed mask string) in DML payloads.
+
+## 14.4 Data Sensitivity Considerations
+
+CDC streams by definition carry the full before/after state of every changed row. In regulated environments (GDPR, HIPAA, PCI-DSS), this means the stream itself is sensitive data. Implementers MUST assess:
+
+- Whether the CDC stream transport path is fully within the data's authorized processing boundary
+
+- Whether stream storage (Kafka topics, trail files, S3 buckets) applies the same access controls as the source database
+
+- Whether replay capabilities (which allow historical data retrieval) are subject to the same data retention and deletion obligations as the source system
+
+# 15. Operational Modes
+
+OpenCDC events may be used in two distinct operational modes that have different requirements for durability, replay, and data loss tolerance. Implementations MUST declare which mode(s) they support. A single deployment MAY operate in both modes simultaneously for different consumer types.
+
+## 15.1 Durable Mode
+
+Durable Mode is the default and primary mode for OpenCDC. It is required for all use cases where data loss is unacceptable: database replication, lakehouse ingestion, and any consumer that maintains a persistent target state.
+
+- **Replay support**
+  - Producer Obligation: MUST support Approach 1 and/or Approach 2 reconnection (Section 6.4). Durable stream MUST be accessible for replay.
+  - Consumer Obligation: MUST persist resume position (cdcpos) after each successfully applied event. MUST resume from saved position on reconnect.
+
+- **Event durability**
+  - Producer Obligation: MUST persist events to durable storage before acknowledging delivery. Lost events that cannot be replayed are a conformance violation.
+  - Consumer Obligation: MUST NOT assume at-most-once delivery. MUST implement idempotent apply to handle replayed events.
+
+- **Data loss**
+  - Producer Obligation: Zero data loss MUST be the design target. Gaps in the event stream MUST be surfaced as errors, not silently skipped.
+  - Consumer Obligation: MUST detect and surface gaps (cdctxorder discontinuities, missing transactions). MUST NOT apply events after detecting a gap without operator acknowledgement.
+
+- **Schema availability**
+  - Producer Obligation: MUST guarantee schema availability for replay (Section 6.4, Approach 1 and/or 2).
+  - Consumer Obligation: MUST NOT apply a DML event without first resolving its schema.
+
+## 15.2 Ephemeral Mode
+
+**Ephemeral Mode Is NOT Conformant for Core Stories**
+Ephemeral Mode MUST NOT be used for the core durable-replication use cases (cross-vendor replication, same-type replication, lakehouse ingestion). Those use cases require zero data loss and durable replay; any implementation claiming conformance for them MUST operate in Durable Mode. Ephemeral Mode is valid only for use cases such as reactive AI-agent streams, live monitoring dashboards, alerting feeds, and any other case where the application explicitly accepts that events may be missed during outages without constituting a data integrity failure.
+
+Ephemeral Mode is appropriate for use cases where real-time event delivery is the priority and brief data loss is explicitly acceptable: reactive AI-agent pipelines, live dashboards, alerting systems, and monitoring feeds where a gap in coverage is tolerable.
+
+- **Replay support**
+  - Producer Obligation: OPTIONAL. Producer MAY support replay but is not required to. Stream position (cdcpos) MUST still be emitted on every event for consumers that choose to persist it.
+  - Consumer Obligation: OPTIONAL. Consumer MAY reconnect to the current stream position ("now") without requesting historical replay.
+
+- **Event durability**
+  - Producer Obligation: SHOULD persist events where feasible, but MAY use in-memory or ring-buffer delivery if the use case explicitly accepts data loss.
+  - Consumer Obligation: MUST NOT assume missed events will be replayed. Application logic MUST tolerate gaps in the event stream.
+
+- **Data loss**
+  - Producer Obligation: Explicitly acceptable. Producers and consumers MUST document their data loss tolerance.
+  - Consumer Obligation: A gap in the event stream is an accepted condition, not an error requiring operator action.
+
+- **Schema availability**
+  - Producer Obligation: MUST still emit OBJECT_METADATA before first DML and after DDL -- even in ephemeral mode. Schema delivery is not optional in any mode.
+  - Consumer Obligation: MUST still cache and apply schema before decoding DML values. Schema correctness is required even when data loss is tolerated.
+
+**Schema Delivery Is Not Optional in Ephemeral Mode**
+Even in Ephemeral Mode, where data loss is acceptable, schema delivery (OBJECT_METADATA before first DML) remains a MUST. A consumer that receives a DML event without a cached schema cannot decode the values -- this is not a data loss scenario, it is a parsing failure. Producers in Ephemeral Mode MUST still implement Approach 1 reconnection (re-emit current schemas on consumer connection). The schema is not stream data -- it is the key to interpreting stream data.
+
+# 16. Implementation Safety Notes
+
+The production-deployment best practices formerly recorded here (schema-mismatch logging, ordering-gap detection, replay consistency checks, sequence-continuity monitoring, HEARTBEAT-lag monitoring, duplicate-rate tracking, and type-decode error isolation) are operational guidance for implementers rather than producer conformance requirements. They are collected, together with the consumer service-level guidance, in Appendix A.8 (Implementation Safety & Monitoring Notes).
+
+# 17. Normative Summary
+
+The following table consolidates the MUST requirements across the specification for implementer quick-reference. Producer obligations (P-*, producer-side T-*, S-*, and R-*) are normative for this specification. Consumer obligations (C-* and consumer-side R-*) are retained in this table for a complete cross-reference but are non-normative here; they are defined as service-level guidance in Appendix A. SHOULD requirements are not listed -- see the relevant section for the complete normative text.
+
+- **P-ORD-1**
+  - Requirement: Emit events in source transaction log order
+  - Who: Producer
+  - Section: 6.1
+
+- **P-ORD-2**
+  - Requirement: All events in same transaction carry same cdcxid
+  - Who: Producer
+  - Section: 6.1
+
+- **P-ORD-3**
+  - Requirement: cdctxorder is 0-based, monotonically increasing within transaction
+  - Who: Producer
+  - Section: 6.1
+
+- **P-ORD-4**
+  - Requirement: OBJECT_METADATA MUST precede first DML for a table
+  - Who: Producer
+  - Section: 4.1, 6.1
+
+- **P-ORD-5**
+  - Requirement: New OBJECT_METADATA MUST follow DDL, precede next DML
+  - Who: Producer
+  - Section: 4.1, 6.1
+
+- **P-ORD-6**
+  - Requirement: All events of same transaction MUST share same partitionkey
+  - Who: Producer
+  - Section: 3.3, 6.1
+
+- **P-TYPE-1**
+  - Requirement: source_type carries verbatim DDL -- no normalization
+  - Who: Producer
+  - Section: 6.2
+
+- **P-TYPE-2**
+  - Requirement: logical_type from OpenCDC canonical vocabulary
+  - Who: Producer
+  - Section: 6.2
+
+- **P-TYPE-3**
+  - Requirement: DML values encoded per logical_type wire rules
+  - Who: Producer
+  - Section: 6.2
+
+- **P-TYPE-4**
+  - Requirement: No silent truncation or precision loss
+  - Who: Producer
+  - Section: 6.2
+
+- **P-LOB-1**
+  - Requirement: _null_columns and _lob_overflow distinguish null vs uncaptured
+  - Who: Producer
+  - Section: 6.3
+
+- **P-LOB-2**
+  - Requirement: _null_columns and _lob_overflow present in every DML (even empty)
+  - Who: Producer
+  - Section: 6.3
+
+- **P-CONN-1**
+  - Requirement: Approach 1 reconnection: re-emit schemas on connection
+  - Who: Producer
+  - Section: 6.4
+
+- **P-LOOP-1**
+  - Requirement: Loop suppression in bidirectional sync (source field matching)
+  - Who: Producer
+  - Section: 3.4
+
+- **T-COMPLETE**
+  - Requirement: Transaction complete when new cdcxid (or HEARTBEAT) observed after last event in group
+  - Who: Producer
+  - Section: 8.3
+
+- **T-NOINTERLEAVE**
+  - Requirement: Events from different transactions MUST NOT be interleaved
+  - Who: Producer
+  - Section: 8.3
+
+- **T-ORDER**
+  - Requirement: cdctxorder MUST be gapless and monotonic within a transaction
+  - Who: Producer
+  - Section: 8.3
+
+- **T-HEARTBEAT**
+  - Requirement: Producer MUST emit HEARTBEAT within heartbeat_interval_seconds after idle transaction
+  - Who: Producer
+  - Section: 8.3
+
+- **P-IDEM-1**
+  - Requirement: Stable UUID id assigned at creation; same id during replay
+  - Who: Producer
+  - Section: 11.2
+
+- **C-ORD-1**
+  - Requirement: Apply events in cdctxorder sequence within transaction
+  - Who: Consumer
+  - Section: Appendix A.1
+
+- **C-ORD-2**
+  - Requirement: Apply transactions in stream order; buffer out-of-order events
+  - Who: Consumer
+  - Section: Appendix A.1
+
+- **C-ORD-3**
+  - Requirement: On unknown dataschema: pause and request schema, or reject -- MUST NOT infer
+  - Who: Consumer
+  - Section: Appendix A.1
+
+- **C-SCHEMA-1**
+  - Requirement: Detect schema version changes
+  - Who: Consumer
+  - Section: Appendix A.2
+
+- **C-SCHEMA-2**
+  - Requirement: Update schema cache on OBJECT_METADATA receipt
+  - Who: Consumer
+  - Section: Appendix A.2
+
+- **C-SCHEMA-3**
+  - Requirement: Do not apply DML with stale schema
+  - Who: Consumer
+  - Section: Appendix A.2
+
+- **C-IDEM-1**
+  - Requirement: Deduplicate on (source, id)
+  - Who: Consumer
+  - Section: Appendix A.3, A.7
+
+- **C-IDEM-2**
+  - Requirement: Discard duplicates silently without error
+  - Who: Consumer
+  - Section: Appendix A.3
+
+- **C-LOB-1**
+  - Requirement: Check _lob_overflow before interpreting LOB null
+  - Who: Consumer
+  - Section: Appendix A.4
+
+- **C-LOB-2**
+  - Requirement: Do not treat lob_overflow null as schema-level null
+  - Who: Consumer
+  - Section: Appendix A.4
+
+- **C-VAL-1**
+  - Requirement: Validate DML against json_schema; reject on failure
+  - Who: Consumer
+  - Section: Appendix A.5
+
+- **C-VAL-2**
+  - Requirement: Reject events with unrecognized fields
+  - Who: Consumer
+  - Section: Appendix A.5
+
+- **R-POS-1**
+  - Requirement: Persist (pos.lsn, pos.lsn_offset) as structured resume position; persist cdcpos as primary replay handle
+  - Who: Consumer
+  - Section: 8.2
+
+- **R-POS-2**
+  - Requirement: Provide cdcpos on resume; producer replays from schema event
+  - Who: Both
+  - Section: 8.2
+
+- **R-POS-4**
+  - Requirement: Replay preserves original event order
+  - Who: Producer
+  - Section: 8.2
+
+- **S-TLS-1**
+  - Requirement: All connections use TLS 1.2+
+  - Who: Both
+  - Section: 14.1
+
+- **S-AUTH-1**
+  - Requirement: Mutual authentication before stream establishment
+  - Who: Both
+  - Section: 14.2
+
+- **P-SCHEMA-1**
+  - Requirement: schema_on_change MUST always be true in STREAM_METADATA schema_delivery
+  - Who: Producer
+  - Section: 4.4, 4.5.1
+
+- **P-SCHEMA-2**
+  - Requirement: At least one of schema_on_reconnect or schema_on_each_event MUST be true
+  - Who: Producer
+  - Section: 4.4
+
+- **P-SCHEMA-3**
+  - Requirement: schema_delivery object MUST be present in every STREAM_METADATA event
+  - Who: Producer
+  - Section: 4.4, 10.4
+
+- **P-SCHEMA-4**
+  - Requirement: If schema_on_reconnect: false, then schema_on_each_event MUST be true
+  - Who: Producer
+  - Section: 4.4, 4.5.2
+
+- **P-SCHEMA-5**
+  - Requirement: If schema_on_each_event: true, _schema object MUST be present in every DML data payload
+  - Who: Producer
+  - Section: 4.5.3
+
+- **C-SCHEMA-4**
+  - Requirement: Consumer MUST read schema_delivery in STREAM_METADATA and adapt schema acquisition behavior
+  - Who: Consumer
+  - Section: 4.4
+
+- **P-SEQ-1**
+  - Requirement: CloudEvents sequence value MUST be a non-negative decimal integer encoded as string, no leading zeros
+  - Who: Producer
+  - Section: 3.3
+
+- **P-SEQ-2**
+  - Requirement: CloudEvents sequence MUST be monotonically increasing within a session; gaps are permitted
+  - Who: Producer
+  - Section: 3.3
+
+- **P-SEQ-3**
+  - Requirement: CloudEvents sequence MUST NOT be derived from source database positions; it is producer-assigned
+  - Who: Producer
+  - Section: 3.3
+
+- **P-SEQ-4**
+  - Requirement: sequence_continuity MUST be present in every STREAM_METADATA event
+  - Who: Producer
+  - Section: 8.4.1, 10.4
+
+- **P-SEQ-5**
+  - Requirement: When LSN or sequence continuity breaks mid-session, producer MUST emit HEARTBEAT with lsn_reset or sequence_reset
+  - Who: Producer
+  - Section: 8.4.2
+
+- **P-SEQ-6**
+  - Requirement: pos.lsn MUST be monotonically increasing within a session unless lsn_reset: true or sequence_continuity: "reset" has been signaled
+  - Who: Producer
+  - Section: 8.1, 8.4
+
+- **C-SEQ-1**
+  - Requirement: Consumer MUST NOT interpret CloudEvents sequence gaps as evidence of dropped events
+  - Who: Consumer
+  - Section: 3.3
+
+- **C-SEQ-2**
+  - Requirement: Consumer MUST NOT compare pos.lsn values across sessions when sequence_continuity is "reset" or "best_effort"
+  - Who: Consumer
+  - Section: 8.4.1
+
+- **C-SEQ-3**
+  - Requirement: Consumer MUST treat CloudEvents sequence counter as restarted after reconnect
+  - Who: Consumer
+  - Section: 3.3, 8.4
+
+- **C-SEQ-4**
+  - Requirement: Consumer MUST use cdctxorder for intra-transaction ordering, CloudEvents sequence for cross-table total ordering, and (pos.lsn, pos.lsn_offset) for replay positioning
+  - Who: Consumer
+  - Section: 3.3, 8.1, 8.2
+
+- **P-TRUNC-1**
+  - Requirement: When emitting a TRUNCATE event, before and after MUST be null; _null_columns and _lob_overflow MUST be present and empty; primary_key MUST be populated
+  - Who: Producer
+  - Section: 10.2.4
+
+- **P-TRUNC-2**
+  - Requirement: For multi-table TRUNCATE (single SQL statement naming multiple tables), producer MUST emit one TRUNCATE event per table; all events MUST share the same cdcxid; cdctxorder MUST be sequential (0, 1, 2, ...)
+  - Who: Producer
+  - Section: 6.1 (P-ORD-7), 10.2.3
+
+- **P-TRUNC-3**
+  - Requirement: For non-transactional TRUNCATE (Oracle, MySQL), producer MUST assign a synthetic cdcxid that is unique, stable across replay, and documented
+  - Who: Producer
+  - Section: 10.2.2, 8.3
+
+- **P-TRUNC-4**
+  - Requirement: If a producer emits TRUNCATE events and the source engine exposes truncate execution options, the producer SHOULD populate truncate_details; producers MUST NOT fabricate flag values that cannot be determined from the capture layer
+  - Who: Producer
+  - Section: 10.2.5, 2.8
+
+- **C-TRUNC-1**
+  - Requirement: Consumers MUST treat any TRUNCATE event as semantically equivalent to deletion of all rows in the named table, regardless of truncate_details presence
+  - Who: Consumer
+  - Section: 10.2.1, Appendix A.6
+
+- **C-TRUNC-2**
+  - Requirement: Consumers performing correctness-sensitive (same-engine) replication SHOULD inspect truncate_details.cascade and truncate_details.sequence_reset when present and act on non-"not_applicable" values
+  - Who: Consumer
+  - Section: Appendix A.6
+
+- **C-TRUNC-3**
+  - Requirement: Consumers performing target-agnostic apply MAY ignore truncate_details; consumers MUST NOT reject a TRUNCATE event solely because truncate_details is present
+  - Who: Consumer
+  - Section: Appendix A.6
+
+# 18. Design Decision Record
+
+The deliberate design decisions behind this specification -- what was adopted, what was rejected, and why -- are recorded in the companion OpenCDC Architecture Decision Record (ADR) v0.1 (see Normative References). They are maintained there, in numbered ADR entries, rather than inline, so this document can stay focused on defining the specification itself.
+
+# 19. Conformance
+
+An implementation is a conforming OpenCDC producer if it satisfies all P-* (and producer-side T-*, S-*, and R-*) requirements in the Normative Summary (Section 17). The consumer-side obligations needed to interoperate with a conformant producer (C-* and consumer R-* requirements) are defined, as non-normative service-level guidance, in Appendix A. An implementation that operates as both producer and consumer (e.g., a replication tool in bidirectional sync) is expected to satisfy both.
+
+Conformance with this specification additionally requires conformance with:
+
+- CloudEvents Specification v1.1 -- all produced events MUST be valid CloudEvents v1.1 documents
+
+- OpenCDC Type System Proposal v0.2 -- all source_type, logical_type, parameters, and wire encoding values MUST conform to the Type System Proposal
+
+- JSON Schema 2020-12 -- all json_schema blocks in OBJECT_METADATA events MUST be valid JSON Schema 2020-12 documents with additionalProperties: false
+
+Conformance testing guidance: A conformant stream can be validated end-to-end using only a JSON parser, a JSON Schema 2020-12 validator, and the OpenCDC specification documents. No vendor-specific tooling is required. This is a design requirement, not a convenience -- a validator that requires vendor tools is testing the vendor tool, not the stream.
+
+## 19.1 Compliance Matrix
+
+The "Consumer MUST" / "Consumer SHOULD" entries below describe what a consumer must do to interoperate with a conformant producer at full fidelity. They are non-normative within this producer-focused specification and are defined as service-level guidance in Appendix A; the matrix retains them for a complete interoperability view.
+
+- **Schema delivery before first DML**
+  - Producer MUST: yes
+  - Consumer MUST: yes
+  - Both MUST:
+  - Section: 4.1
+
+- **Schema re-emission after DDL**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 4.1
+
+- **Schema re-emission on reconnect**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 6.4
+
+- **Closed-world schema enforcement**
+  - Producer MUST: yes
+  - Consumer MUST: yes
+  - Both MUST:
+  - Section: 4.2
+
+- **source_type verbatim DDL**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 4.3
+
+- **logical_type from OpenCDC vocabulary**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 4.3
+
+- **logical_type authoritative for decoding**
+  - Producer MUST:
+  - Consumer MUST: yes
+  - Both MUST:
+  - Section: 4.3
+
+- **Values-only DML payloads (no per-row types)**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 5
+
+- **_null_columns and _lob_overflow present in every DML**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 5.2
+
+- **Absent column = unchanged (not null)**
+  - Producer MUST:
+  - Consumer MUST: yes
+  - Both MUST:
+  - Section: 5.4
+
+- **Transaction non-interleaving**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 8.3
+
+- **cdctxorder monotonic within transaction**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 6.1
+
+- **Apply events in cdctxorder sequence**
+  - Producer MUST:
+  - Consumer MUST: yes
+  - Both MUST:
+  - Section: Appendix A.1
+
+- **Stable UUID id (unchanged during replay)**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 11.2
+
+- **Deduplicate on (source, id)**
+  - Producer MUST:
+  - Consumer MUST: yes
+  - Both MUST:
+  - Section: Appendix A.3
+
+- **Persist and restore cdcpos**
+  - Producer MUST:
+  - Consumer MUST: yes
+  - Both MUST:
+  - Section: 8.2
+
+- **Replay begins at/before schema event**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 8.2
+
+- **HEARTBEAT during idle periods**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 10.1
+
+- **Monitor HEARTBEAT for liveness**
+  - Producer MUST:
+  - Consumer MUST: yes
+  - Both MUST:
+  - Section: 10.1
+
+- **TLS 1.2+ on all connections**
+  - Producer MUST:
+  - Consumer MUST:
+  - Both MUST: yes
+  - Section: 14.1
+
+- **Mutual authentication**
+  - Producer MUST:
+  - Consumer MUST:
+  - Both MUST: yes
+  - Section: 14.2
+
+- **Loop suppression (bidirectional sync)**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 3.4
+
+- **TRUNCATE: before=null, after=null, primary_key populated**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 10.2.4
+
+- **TRUNCATE: _null_columns and _lob_overflow present and empty**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 10.2.4
+
+- **TRUNCATE: minimum semantics (delete all rows) applied regardless of truncate_details**
+  - Producer MUST:
+  - Consumer MUST: yes
+  - Both MUST:
+  - Section: 10.2.1, Appendix A.6
+
+- **TRUNCATE: truncate_details SHOULD be populated when engine exposes options**
+  - Producer SHOULD: yes
+  - Consumer SHOULD:
+  - Both SHOULD:
+  - Section: 10.2.5, 2.8
+
+- **TRUNCATE: correctness-sensitive consumers SHOULD inspect truncate_details**
+  - Producer SHOULD:
+  - Consumer SHOULD: yes
+  - Both SHOULD:
+  - Section: Appendix A.6
+
+- **Multi-table TRUNCATE: one event per table, shared cdcxid, sequential cdctxorder**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 6.1 (P-ORD-7), 10.2.3
+
+- **Non-transactional TRUNCATE (Oracle, MySQL): synthetic cdcxid required**
+  - Producer MUST: yes
+  - Consumer MUST:
+  - Both MUST:
+  - Section: 10.2.2, 8.3
+
+- **Payload encoding preserves field semantics**
+  - Producer MUST: yes
+  - Consumer MUST: yes
+  - Both MUST:
+  - Section: 2.7
+
+## 19.2 Conformance Test Scenarios
+
+The following scenarios are the minimum test suite for conformance validation. Each scenario maps to one or more acceptance criteria in the informative OpenCDC User Stories document; the User Story tags are retained for traceability to that document.
+
+- **T-01**
+  - Scenario: Cross-vendor DML exchange (INSERT, UPDATE, DELETE)
+  - Pass Criterion: Consumer applies all three operations correctly using only the OpenCDC schema and no vendor-specific logic
+  - User Story: Story 1, 2
+
+- **T-02**
+  - Scenario: Schema evolution: ALTER TABLE adds column
+  - Pass Criterion: Consumer detects schema_version increment, updates cache, correctly decodes new column in subsequent DML
+  - User Story: Story 2, 3
+
+- **T-03**
+  - Scenario: Replay after outage (resume from saved cdcpos)
+  - Pass Criterion: Consumer reconnects, receives STREAM_METADATA + current OBJECT_METADATA, then resumes data from saved position with no missed or duplicate events applied
+  - User Story: Story 1, 2, 5
+
+- **T-04**
+  - Scenario: Duplicate event delivery
+  - Pass Criterion: Consumer receives same (source, id) pair twice. Second delivery is silently discarded. Target state is identical to single-delivery result.
+  - User Story: Story 2, 3
+
+- **T-05**
+  - Scenario: LOB null vs overflow
+  - Pass Criterion: Consumer receives event with column in _null_columns and different column in _lob_overflow. Both have JSON null value. Consumer correctly distinguishes them.
+  - User Story: Story 3
+
+- **T-06**
+  - Scenario: Partial UPDATE image
+  - Pass Criterion: Consumer receives UPDATE with changed_columns present. Correctly interprets absent columns as unchanged. Does not overwrite target with null for absent columns.
+  - User Story: Story 2
+
+- **T-07**
+  - Scenario: Multi-row atomic transaction
+  - Pass Criterion: Consumer receives 3 INSERT events sharing cdcxid. Applies all three atomically. If interrupted after event 2, re-applies all 3 on reconnect via idempotent apply.
+  - User Story: Story 2
+
+- **T-08**
+  - Scenario: Bidirectional sync loop prevention
+  - Pass Criterion: System A change -> System B applies -> System B does NOT re-emit event back to System A.
+  - User Story: Story 5
+
+- **T-09**
+  - Scenario: Type fidelity: Oracle DATE
+  - Pass Criterion: Consumer receives ORACLE_DATE column. Correctly preserves time component. Does not strip to calendar date.
+  - User Story: Story 1, 5
+
+- **T-10**
+  - Scenario: Encoding agnosticism
+  - Pass Criterion: Producer emits events in Avro (or Protobuf). Consumer correctly decodes all fields and type values. No JSON parser required.
+  - User Story: Story 3, 4
+
+- **T-11**
+  - Scenario: TRUNCATE -- minimum semantics
+  - Pass Criterion: Consumer receives a TRUNCATE event (with or without truncate_details). Consumer applies "delete all rows" to the target table. before and after are confirmed null. _null_columns and _lob_overflow are confirmed present and empty. Consumer does not fail or reject the event.
+  - User Story: Story 1, 2
+
+- **T-12**
+  - Scenario: TRUNCATE -- truncate_details inspection (correctness-sensitive)
+  - Pass Criterion: Consumer receives a PostgreSQL TRUNCATE event with truncate_details: { cascade: true, sequence_reset: true, multi_table: false }. Consumer applies TRUNCATE CASCADE on the same-engine target and resets the target table's identity sequence. If target engine does not support CASCADE or identity reset, consumer logs the flag values and applies minimum semantics without error.
+  - User Story: Story 1, 2
+
+- **T-13**
+  - Scenario: TRUNCATE -- multi-table, shared cdcxid
+  - Pass Criterion: Producer emits TRUNCATE events for tables A, B, and C from a single TRUNCATE A, B, C; statement. All three events carry the same cdcxid. cdctxorder values are 0, 1, 2 respectively. multi_table is true on all three. Consumer applies all three truncations atomically within the same cdcxid group and does not treat them as three independent transactions.
+  - User Story: Story 2
+
+- **T-14**
+  - Scenario: TRUNCATE -- non-transactional (Oracle/MySQL) synthetic cdcxid
+  - Pass Criterion: Producer emits an Oracle TRUNCATE event with a synthetic cdcxid (not a real Oracle transaction ID). The synthetic cdcxid is stable: replay of the same event carries the same synthetic cdcxid. Consumer deduplicates on (source, id) correctly, not on cdcxid alone. truncate_details shows cascade: "not_applicable" and sequence_reset: "not_applicable".
+  - User Story: Story 1, 2
+
+OpenCDC Specification -- Draft v0.6 -- June 2026 -- OpenCDC Working Group
+
+# Appendix A: Consumer Conformance, Obligations & Service-Level Guidance
+
+This appendix is non-normative with respect to this specification, which governs producer behavior (see Document Authority and Scope). A conformant producer emits a stream that a consumer can read and interpret with full fidelity. What a consumer must then do depends on the service level it targets: strict transactionality and exact type fidelity for a financial replication target, or looser handling for a reporting tool that computes coarse aggregates. The obligations below are the behaviors a consumer adopts to achieve full-fidelity interoperability with a conformant producer. A consumer that targets a lower service level MAY relax obligations marked SHOULD or MAY, but a consumer that relaxes a MUST below forfeits the corresponding fidelity guarantee. Keyword conventions (MUST, SHOULD, MAY) are used here to describe those service-level expectations, not to impose specification conformance on consumers.
+
+This appendix consolidates the consumer guidance formerly in Section 7, the consumer idempotency obligations formerly in Section 11.3, and the implementation safety notes formerly in Section 16.
+
+A consumer is any system that receives and applies OpenCDC events -- a CDC tool acting as a target, a pipeline processor, a lakehouse ingestion layer, or an application subscriber. The obligations below describe how a consumer achieves a given service level against a conformant producer; they are not specification conformance requirements on the consumer.
+
+## A.1 Ordering Obligations
+
+- C-ORD-1: Consumers MUST apply events within a transaction in cdctxorder sequence. Applying events out of order within a transaction produces incorrect results and is a consumer conformance violation.
+
+- C-ORD-2: Consumers MUST apply transactions in stream order. If events arrive out of order (e.g., due to Kafka partition rebalancing), consumers MUST buffer and reorder before applying.
+
+- C-ORD-3 (Missing Schema Handling): Consumers MUST NOT apply a DML event whose dataschema value is not in their schema cache. On receipt of a DML event with an unknown dataschema value, a consumer MUST take exactly one of the following actions: (a) check whether the DML event contains an embedded _schema object (Schema on Each Event mode, Section 4.5.3) and if present with consistent schema_version, use it to resolve the reference and proceed; (b) pause processing and request schema re-emission by triggering a reconnect (Approach 1, Section 6.4 / Section 4.5.2); or (c) reject the event and surface an error. A consumer MUST NOT attempt to infer the schema from the event payload, guess field types from value shapes, or proceed with partial type information. Silent schema inference is a correctness violation that will produce silently wrong results for engine-specific types (ORACLE_DATE, UINT64, MYSQL_TIMESTAMP, etc.).
+
+## A.2 Schema Evolution Obligations
+
+- C-SCHEMA-1: Consumers MUST detect schema version changes by comparing the schema_version in the received OBJECT_METADATA against the last cached version for that table.
+
+- C-SCHEMA-2: Consumers MUST update their schema cache immediately upon receiving a new OBJECT_METADATA event. The new schema MUST be applied to all subsequent DML events referencing the new schema id.
+
+- C-SCHEMA-3: Consumers MUST NOT apply a DML event using a stale schema version. If the dataschema reference does not match the consumer's cached schema id, the consumer MUST NOT apply the event and MUST surface an error.
+
+## A.3 Idempotency Obligations
+
+- C-IDEM-1: Consumers MUST support idempotent event application. The same event (identified by the (source, id) pair) MAY be delivered more than once in at-least-once delivery scenarios. Consumers MUST detect and suppress duplicate events.
+
+- C-IDEM-2: The deduplication key is the tuple (source, id). These two CloudEvents fields together uniquely identify an event. Consumers MUST persist the set of applied (source, id) pairs for a sufficient lookback window to suppress late duplicates.
+
+- C-IDEM-3: Consumers SHOULD implement idempotent apply semantics at the target level (e.g., INSERT OR REPLACE, UPDATE WHERE primary_key = x AND version = y) so that re-application of a duplicate event produces the same result as first application.
+
+## A.4 LOB Handling Obligations
+
+- C-LOB-1: Consumers MUST check _lob_overflow for any column whose value is JSON null before interpreting that null as the column's actual value. A column name present in _lob_overflow means the content was not captured -- the consumer cannot distinguish the actual value without a supplemental query.
+
+- C-LOB-2: Consumers MUST NOT interpret an _lob_overflow null as equivalent to a schema-level null. The source row's column was not null -- its content simply was not available to the capture layer.
+
+## A.5 Validation Obligations
+
+- C-VAL-1: Consumers SHOULD validate DML event payloads against the json_schema in the referenced OBJECT_METADATA. Validation failure MUST result in event rejection, not silent processing with partial data.
+
+- C-VAL-2: Consumers MUST reject events with unrecognized fields (additionalProperties: false enforcement). A producer that emits unrecognized fields is non-conformant; a consumer that accepts them silently is also non-conformant.
+
+- C-VAL-3: Consumers SHOULD verify CloudEvents envelope compliance for every received event, including specversion="1.1" and required field presence.
+
+## A.6 TRUNCATE Consumer Obligations
+
+- C-TRUNC-1 (Minimum TRUNCATE semantics): Consumers MUST treat any TRUNCATE event as semantically equivalent to the deletion of all rows in the named table, regardless of whether truncate_details is present. This is the unconditional minimum contract. A consumer that cannot process TRUNCATE events is non-conformant for any deployment where TRUNCATE is expected from the source.
+
+- C-TRUNC-2 (truncate_details -- correctness-sensitive apply): Consumers performing correctness-sensitive replication to a same-engine or semantically equivalent target SHOULD inspect the truncate_details object when present. If cascade is true and the target engine supports cascading truncation, the consumer SHOULD apply TRUNCATE with the CASCADE option (or equivalent). If sequence_reset is true and the target table has an identity or auto-increment sequence, the consumer SHOULD reset that sequence as part of applying the TRUNCATE; if sequence_reset is false, the consumer SHOULD preserve the existing sequence state. If cascade or sequence_reset is "not_applicable", the consumer MAY ignore that field -- it carries no actionable information for the current source/target pair. If cascade or sequence_reset is "unknown", the consumer SHOULD apply the target engine's default behavior and SHOULD log the uncertainty for operator visibility.
+
+- C-TRUNC-3 (truncate_details -- target-agnostic apply): Consumers performing target-agnostic apply (e.g., a lakehouse ingestion layer, a message bus consumer, or a cross-vendor replication target) MAY ignore the truncate_details object entirely and apply only the minimum TRUNCATE semantics (delete all rows). Such consumers MUST NOT fail or reject a TRUNCATE event solely because truncate_details is present; they MUST silently ignore the object when it is not actionable.
+
+- C-TRUNC-4 (TRUNCATE idempotency): TRUNCATE events participate in the standard (source, id) deduplication mechanism (Appendix A.3). A consumer that receives a duplicate TRUNCATE event (same (source, id) pair) MUST apply standard deduplication and MUST NOT re-apply the truncation.
+
+## A.7 Consumer Idempotency Obligations
+
+- Consumers MUST maintain a deduplication set of (source, id) pairs for a lookback window sufficient to catch late duplicates (minimum: the maximum expected redelivery window for the transport layer).
+
+- Consumers MUST silently discard duplicate events without error. A duplicate is not a stream error -- it is an expected delivery artifact.
+
+- Consumers SHOULD implement idempotent apply semantics at the target level. Examples: INSERT OR REPLACE, MERGE with version check, UPDATE WHERE current_value = before_value.
+
+**Atomic Multi-Row Transaction Apply**
+Reliable replication requires that multi-row transactions are applied atomically. Combined with at-least-once delivery, this means consumers must be able to: (a) detect that a partial transaction was applied before a failure, (b) roll back the partial application, and (c) re-apply the full transaction from the beginning when the events are redelivered. Idempotent apply semantics at the row level make (c) safe even when (b) is not implemented.
+
+## A.8 Implementation Safety & Monitoring Notes
+
+The following are SHOULD-level best practices for production deployments. They are not required for producer conformance but represent best practice for consumers and operators. Implementations that omit them SHOULD document the omission.
+
+- **Schema mismatch logging**
+  - Recommendation: Log a warning (with source, table, schema_version, and dataschema id) whenever a received DML event's dataschema does not match the cached schema id, even if the consumer handles it gracefully.
+  - Rationale: Enables detection of producer non-conformance and schema delivery race conditions in distributed deployments.
+
+- **Ordering gap detection**
+  - Recommendation: Detect and log gaps in cdctxorder (e.g., sequence jumps from 2 to 4 within the same cdcxid). Surface as an error if gaps cannot be explained by a reconnect.
+  - Rationale: Gaps indicate lost events -- a producer conformance failure. Silent acceptance corrupts the target.
+
+- **Replay consistency check**
+  - Recommendation: After replay, verify that the first replayed event's (pos.lsn, pos.lsn_offset) is at or before the saved resume position. Log a warning if replay starts after the saved position. If sequence_continuity: "reset" was declared in STREAM_METADATA for this session, do not compare pos.lsn values to prior-session saved positions -- reset the resume position baseline to the first event received in the new session.
+  - Rationale: Detects producer Approach 2 failures where the replay window is too narrow.
+
+- **Sequence continuity monitoring**
+  - Recommendation: On each HEARTBEAT, check lsn_reset and sequence_reset fields. If either is true, log the discontinuity event with timestamp, last known (pos.lsn, pos.lsn_offset), and STREAM_METADATA sequence_continuity value for this session. Alert operators if lsn_reset occurs outside of a planned maintenance window.
+  - Rationale: Unexpected mid-session LSN resets indicate unplanned failover or source instability requiring operator awareness, even if the stream continues correctly.
+
+- **HEARTBEAT lag monitoring**
+  - Recommendation: Track the time since the last HEARTBEAT. Alert if lag exceeds 3x the configured heartbeat_interval_seconds.
+  - Rationale: Distinguishes idle streams from broken capture processes -- a critical operational distinction.
+
+- **Duplicate rate tracking**
+  - Recommendation: Track the rate of (source, id) duplicates observed. Alert if duplicate rate exceeds a configurable threshold (e.g., >1% of events).
+  - Rationale: A high duplicate rate indicates a replay or reconnect loop -- a producer or transport issue requiring investigation.
+
+- **Type decode error isolation**
+  - Recommendation: On encountering a value that cannot be decoded per its logical_type wire encoding rules, reject that column's value and null it with an error marker rather than failing the entire event.
+  - Rationale: Prevents a single malformed column from blocking application of an otherwise valid event.
+
+OpenCDC Working Group -- Draft for Discussion


### PR DESCRIPTION
## Refactor spec to producer-focused v0.6 + add companion ADR

Editorial/structural refactor. **No change to producer wire contract, field semantics, ordering guarantees, or type rules.**

### Spec (v0.5 → v0.6)
- **Extracted decision narrative to a new ADR.** Removed §2.9 (GoldenGate/Debezium evaluation); replaced §18 (Design Decision Record) and Appendix A (Design Rationale) with pointer stubs; trimmed competitive asides in §9 and §10.2 to neutral technical rationale.
- **Thinned references.** Removed superficial vendor-tool mentions (Debezium now 0) and specific User Story citations. Kept vendor mentions only where a source-engine type/behavior defines a concept (UINT64/MySQL, DECFLOAT/Db2, ORACLE_DATE, per-engine TRUNCATE semantics, etc.).
- **Reframed around producers.** Relocated the Consumer Contract (§7), consumer idempotency obligations (§11.3), and Implementation Safety Notes (§16) into a new **Appendix A: Consumer Conformance, Obligations & Service-Level Guidance**. Consumer behavior is now non-normative; remaining in-body mentions are illustrative. Added a producer-scope note to *Document Authority and Scope*.
- **Fixed two pre-existing broken cross-refs:** cdcpos replay (§7→§8) and conformance rules (§15→§17).

### New file
- `OpenCDC-ADR.md` (v0.1) — 24 decision records in MADR/Nygard format (Status/Context/Decision/Consequences/Alternatives).

### Notes for reviewers
- Top-level section numbers preserved (§7/§16/§18 are stubs) to avoid breaking cross-references — no renumbering.
- §17/§19 reference tables retain consumer rows with a non-normative scoping note; refs repointed to Appendix A.